### PR TITLE
Fixed #6 -- Use 127.0.0.1 instead of localhost.

### DIFF
--- a/django_admin/README.md
+++ b/django_admin/README.md
@@ -13,7 +13,7 @@ As you can see, we import (include) the Post model defined in the previous chapt
 
 Ok, time to look at our Post model. Go to the browser and type an address:
 
-    http://localhost:8000/admin/
+    http://127.0.0.1:8000/admin/
 
 You will see a login page like this:
 

--- a/starting_django_project/README.md
+++ b/starting_django_project/README.md
@@ -82,7 +82,7 @@ You need to be in a folder that contains `manage.py` file (in `mysite` directory
 
 Now all you need to do is to check if your website is running :). Open your browser (Firefox, Chrome, Safari, Internet Explorer or whatever you use) and type the address:
 
-    http://localhost:8000/
+    http://127.0.0.1:8000/
 
 Congratulations! You've just created your first website and run it using a web server! Isn't it awesome?
 


### PR DESCRIPTION
Heroku uses Python 2 by default.
To use Python 3, you need to have a `runtime.txt` file.
