### PR TITLE
Explain how to add Postgres to PATH on OS X

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -16,7 +16,9 @@ Choose a newest version available for your operating system. Download this Insta
 
 The easiest way is to download a free [Postgres.app](http://postgresapp.com/) and install it like any other application on your operating system.
 
-Go ahead, download it, drag to the Applications folder and run by double clicking. That's it!
+Go ahead, download it, drag to the Applications folder and run by double clicking.
+
+You'll also have to add the Postgres command line tools to your `PATH` variable, what is described [here](http://postgresapp.com/documentation/cli-tools.html).
 
 ## Linux
 


### PR DESCRIPTION
I guess it's best to link to the Postgresapp documentation so we don't have to update the path (which includes the version number) after a new release.
