### PR TITLE
Updated installation instructions for OSX

### DIFF
--- a/python_installation/README.md
+++ b/python_installation/README.md
@@ -40,7 +40,16 @@ You type in the console:
 
 ### OS X
 
-You need to go to the website https://www.python.org/downloads/release/python-341/ and install the appropriate package for your operating system.
+You need to go to the website https://www.python.org/downloads/release/python-341/ and download the installer.
+
+* Download *Mac OS X 64-bit/32-bit installer* *DMG* file
+* Double click to open it
+* Double click *Python.mpkg* to run the installer
+
+Verify the installation succeeded by opening *Terminal* and running `python` command:
+
+    $ python3 --version
+    Python 3.4.1
 
 ----
 


### PR DESCRIPTION
I revised OSX Python installation instructions - now with little bit more details how to get Python 3 started on OSX.
