### PR TITLE
`source` command on available on all Linuxes

### DIFF
--- a/django_installation/README.md
+++ b/django_installation/README.md
@@ -36,9 +36,9 @@ The command above will create a folder called `blog` that contains our virtual e
 
     C:\Users\Name> blog\Scripts\activate
 
-on Windows, or:
+on Windows, or use shell command `.` to load the environment to your shell on
 
-    ~$ source blog/bin/activate
+    ~$ . blog/bin/activate
 
 on OS X and Linux.
 


### PR DESCRIPTION
There is a gotcha with shell `source` command with `virtualenv`. `source` is not standard and not available on all Linuxes (or more accurately on their default shells). Instead one should use more common `.`. If you do `source` then some people might simply get `Command not found` when they try to follow the installation instructions.

Namely the late Ubuntus and its `dash` shell might be problematic. The issue is discussed here: https://wiki.ubuntu.com/DashAsBinSh#source
