### PR TITLE
Add venv instructions for Ubuntu 14.04

### DIFF
--- a/django_installation/README.md
+++ b/django_installation/README.md
@@ -37,6 +37,17 @@ where `C:\Python34\python` is the folder in which you previously installed Pytho
 Creating a `virtualenv` on both Linux and OS X is as simple as running:
 
     ~/djangogirls$ python3 -m venv myvenv
+    
+    
+> __NOTE:__ Initiating the virtual environment on Ubuntu 14.04 like this currently gives the following error:
+
+>     Error: Command '['/home/eddie/Slask/tmp/venv/bin/python3', '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1
+
+> To get around this, use the `virtualenv` command instead.
+                                                                            
+>     sudo apt-get install python-virtualenv
+>     ~/djangogirls$ virtualenv myvenv
+
 
 ## Working with virtualenv
 


### PR DESCRIPTION
Add instructions on what to do if the virtualenv command fails on Ubuntu 14.04
