### PR TITLE
Added to post_new to allow 24. Homework: add security to work

### DIFF
--- a/django_forms/README.md
+++ b/django_forms/README.md
@@ -81,7 +81,7 @@ After saving and refreshing the page `http://127.0.0.1:8000` you will obviously 
 
 We open `blog/urls.py` and add a line:
 
-    url(r'^post/new/$', views.post_new),
+    url(r'^post/new/$', views.post_new, name='post_new'),
 
 And the final code will look like this:
 
@@ -91,7 +91,7 @@ And the final code will look like this:
     urlpatterns = patterns('',
         url(r'^$', views.post_list),
         url(r'^post/(?P<pk>[0-9]+)/$', views.post_detail),
-        url(r'^post/new/$', views.post_new),
+        url(r'^post/new/$', views.post_new, name='post_new'),
     )
 
 After refreshing the site, we see an `AttributeError`, since we don't have `post_new` view implemented. Let's add it right now.


### PR DESCRIPTION
If post_new isn’t named, step 24 of the tutorial ends up in an error.
