### PR TITLE
Specify Python interpreter on Ubuntu 14.04

### DIFF
--- a/django_installation/README.md
+++ b/django_installation/README.md
@@ -49,7 +49,7 @@ It will look like this:
 > To get around this, use the `virtualenv` command instead.
 
 >     ~/djangogirls$ sudo apt-get install python-virtualenv
->     ~/djangogirls$ virtualenv myvenv
+>     ~/djangogirls$ virtualenv --python=python3.4 myvenv
 
 
 ## Working with virtualenv


### PR DESCRIPTION
On a clean Ubuntu 14.04 command `~/djangogirls$ virtualenv myvenv` is failing with this error:

```
nairobi:~/projects/djangogirls$ virtualenv myvenv
New python executable in myvenv/bin/python
Traceback (most recent call last):
  File "/usr/bin/virtualenv", line 3, in <module>
    virtualenv.main()
  File "/usr/lib/python2.7/dist-packages/virtualenv.py", line 825, in main
    symlink=options.symlink)
  File "/usr/lib/python2.7/dist-packages/virtualenv.py", line 985, in create_environment
    site_packages=site_packages, clear=clear, symlink=symlink))
  File "/usr/lib/python2.7/dist-packages/virtualenv.py", line 1277, in install_python
    shutil.copyfile(executable, py_executable)
  File "/usr/lib/python2.7/shutil.py", line 83, in copyfile
    with open(dst, 'wb') as fdst:
IOError: [Errno 13] Permission denied: 'myvenv/bin/python'
```

Selecting `python3.4` as default fix the issue.
