### PR TITLE
Use lazy evaluated ForeignKey references to prevent future problems

### DIFF
--- a/django_models/README.md
+++ b/django_models/README.md
@@ -101,10 +101,9 @@ Let's open `blog/models.py`, remove everything from it and write code like this:
 
     from django.db import models
     from django.utils import timezone
-    from django.contrib.auth.models import User
 
     class Post(models.Model):
-        author = models.ForeignKey(User)
+        author = models.ForeignKey('auth.User')
         title = models.CharField(max_length=200)
         text = models.TextField()
         created_date = models.DateTimeField(


### PR DESCRIPTION
Starting with Django 1.7 there have been multiple people hitting #django
with problems that eventually could be solved using lazy references to
related models instead of class references. Teaching it this ways seems
to be a good way to prevent future issues.
