### PR TITLE
Use original heroku-push repo instead of fork

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -149,7 +149,7 @@ Because our application needs a database, let's create a free [PostgreSQL](http:
 
 One more thing: let's install [heroku-push plugin](https://github.com/ddollar/heroku-push) by running this command:
 
-    $ heroku plugins:install https://github.com/andriykohut/heroku-push
+    $ heroku plugins:install https://github.com/ddollar/heroku-push
 
 Now we can do a simple push to deploy our application:
     


### PR DESCRIPTION
Fix for windows was merged https://github.com/ddollar/heroku-push/pull/11
I'll try to find time to roll-back to `git push` version + recent changes, but for now it should work
