### PR TITLE
Pip freeze

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -44,7 +44,7 @@ Then save it. Done!
 
 ## The `runtime.txt` file
 
-We need to tell Heroku which Python version we want to use. This is simply done by creating a `runtime.txt` and putting the following text inside:
+We need to tell Heroku which Python version we want to use. This is done by creating a `runtime.txt` in the `djangogirls` directory using your editor's "new file" command, and putting the following text (and nothing else!) inside:
 
     python-3.4.2
 


### PR DESCRIPTION
Lots of our students got the impression that "pip freeze > filename" was the standard way of creating a file from the shell, which caused some really confusing problems later on. In particular, a surprising number of students created runtime.txt by running `pip freeze > runtime.txt` method, and then adding  a Python version at the end. This caused endless confusion when Heroku told them that
(Django==1.7.1
dj-database-url==0.3.0
waitress==0.8.9
whitenoise==1.0.5
psycopg2==2.5.3
python-3.4.2) was not a runtime supported by the cedar-14 stack - at one point we had five coaches standing around one poor student trying to work out what had gone wrong!

I've tried to make it clearer that
- the `>` operator performs output redirection
- `pip freeze` isn't really a file-creation command
- you create runtime.txt using your editor
- only the python version should be included in runtime.txt.

I've also removed the word "simply" from this part of the instructions in line with the Coaching Guide.
