### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Example:
     To git@github.com:miohtama/tutorial.git
        b37ca59..fe36152  contributing -> contributing
        
-If you don't want to download the Gitbook Editor app you can also go to the [Gitbook Website](http://gitbook.com), sign up for free and work direclty in your browser.
+If you don't want to download the Gitbook Editor app you can also go to the [Gitbook website](http://gitbook.com), sign up for free and work directly in your browser.
 
 # Making a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,13 +53,11 @@ Either use the Github app for your operating system (mentioned above) or `git` c
 
     git clone git@github.com:yourgithubusername/tutorial.git
 
-Download the [Gitbook Editor](http://help.gitbook.io/editor/README.html) app to your computer.
+Go to the [Gitbook Website](http://gitbook.com) and sign up for free.
 
-Then you can open the tutorial in Gitbook Editor (*File* > *Open book*).
+Then you can open the tutorial in your browser (*File* > *Open book*).
 
-![Gitbook](contributing/images/gitbook.png)
-
-Make any changes in the tutorial using the editor and then save changes (*Book* > *Save all*).
+Make any changes in the tutorial using Gitbook and then save changes (*Book* > *Save all*).
 
 Then commit the changes using `git` and push the changes to your remote Github repository.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,9 @@ Either use the Github app for your operating system (mentioned above) or `git` c
 
     git clone git@github.com:yourgithubusername/tutorial.git
 
-Go to the [Gitbook Website](http://gitbook.com) and sign up for free.
+Download the [Gitbook Editor](https://github.com/GitbookIO/editor/releases) app to your computer.
 
-Then you can open the tutorial in your browser (*File* > *Open book*).
+Then you can open the tutorial in Gitbook Editor (*File* > *Open book*).
 
 Make any changes in the tutorial using Gitbook and then save changes (*Book* > *Save all*).
 
@@ -85,6 +85,8 @@ Example:
     Total 5 (delta 1), reused 0 (delta 0)
     To git@github.com:miohtama/tutorial.git
        b37ca59..fe36152  contributing -> contributing
+       
+If you don't want to download the Gitbook Editor app you can also go to the [Gitbook Website](http://gitbook.com), sign up for free and work direclty in your browser.
 
 # Making a pull request
 
@@ -102,5 +104,7 @@ Github emails will notify you for the follow up process.
 
 # Further information and help
 
-For any questions please [contact DjangoGirls](http://djangogirls.org/).
+GitHub has an excellent [documentation](https://help.github.com/). Check it out if you need help!
+
+For further questions please [contact DjangoGirls](http://djangogirls.org/).
 


### PR DESCRIPTION
Hey Ola!

I was going through the tutorial on how to contribute and I noticed that it's not possible anymore to download the Gitbook editor. Instead you have to sign up on their website and open the book in your browser I guess. I actually couldn't do that and therefore couldn't get a new screenshot because I can't manage to download the tutorial to my computer via git :(. I always get the same error message:

$ git clone git@github.com:annaoz/organizer-manual.git
Cloning into 'organizer-manual' ...
Warning: Permanently added the RSA host key for IP address '192.30.252.130' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights and the repository exists.

Either there's something wrong with the command or I'm making a mistake.

Hope it can be fixed!

Anna

