### PR TITLE
Removed/replaced references to sweet treats

### DIFF
--- a/en/django_admin/README.md
+++ b/en/django_admin/README.md
@@ -40,6 +40,6 @@ Make sure that at least two or three posts (but not all) have the publish date s
 
 If you want to know more about Django admin, you should check Django's documentation: https://docs.djangoproject.com/en/1.7/ref/contrib/admin/
 
-It is probably a good moment to grab a coffee (or tea) and eat something sweet. You created your first Django model - you deserve a little treat!
+This is probably a good moment to grab a coffee (or tea) or something to eat to re-energise yourself. You created your first Django model - you deserve a little timeout!
 
 

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -298,4 +298,4 @@ It'd be good to see if your website will still be working on Heroku, right? Let'
     ...
     $ git push heroku master
 
-And that should be it! Congrats :) 
+And that should be it! Congrats :)

--- a/en/django_templates/README.md
+++ b/en/django_templates/README.md
@@ -70,6 +70,6 @@ It'd be good to see if your website will still be working on Heroku, right? Let'
 
 Congrats! Now go ahead and try adding a new post in your Django admin (remember to add published_date!), then refresh your page to see if the post appears there.
 
-Works like a charm? We're proud! Treat yourself something sweet, you have earned it :)
+Works like a charm? We're proud! Step away from your computer for a bit, you have earned a break. :)
 
 ![Figure 13.4](images/donut.png)

--- a/en/dynamic_data_in_templates/README.md
+++ b/en/dynamic_data_in_templates/README.md
@@ -24,10 +24,10 @@ But what's next? To take actual blog posts from `Post` model we need something c
 
 ## QuerySet
 
-You should already be familiar with how QuerySets work. We talked about it in [Django ORM (QuerySets) chapter](/django_orm/README.html). 
+You should already be familiar with how QuerySets work. We talked about it in [Django ORM (QuerySets) chapter](/django_orm/README.html).
 
 So now we are interested in a list of blog posts that are published and sorted by `published_date`, right? We already did that in QuerySets chapter!
- 
+
     Post.objects.filter(published_date__isnull=False).order_by('published_date')
 
 Now we put this piece of code inside the `blog/views.py` file by adding it to the function `def post_list(request)`:

--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -660,6 +660,6 @@ Note that the second of these two numbers is not included in the list that is ou
 
 That's it. __You totally rock!__ This really wasn't so easy, so you should feel proud of yourself. We're definitely proud of you for making it to here!
 
-Grab yourself a cupcake and go to the next chapter :)
+You might want to briefly do something else - stretch, walk around for a bit, rest your eyes - before going on to the next chapter. :)
 
 ![Cupcake](images/cupcake.png)


### PR DESCRIPTION
In response to #134.

I kept one reference to coffee/tea and changed the sweets to food as I believe the original idea was to re-energise oneself. Another instance uses suggestions often given to people who spend time in front of computers a lot but isn't "overly" healthy either. Hope everyone feels the changes are well-balanced. (:

The other changes I didn't (consciously?) make, maybe GitBook removed those extra spaces for me.

