### PR TITLE
Change some potentially confusing naming

### DIFF
--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -149,11 +149,11 @@ Awesome, right? Of course, variables can be anything, so numbers too! Try this:
 
 But what if we used the wrong name? Can you guess what would happen? Let's try!
 
-    >>> name = "Maria"
-    >>> names
+    >>> city = "Tokyo"
+    >>> ctiy
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    NameError: name 'names' is not defined
+    NameError: name 'ctiy' is not defined
 
 An error! As you can see, Python has different types of errors and this one is called a **NameError**. Python will give you this error if you try to use a variable that hasn't been defined yet. If you encounter this error later, check your code to see if you've mistyped any names.
 


### PR DESCRIPTION
I feel that the line ``NameError: name 'names' is not defined`` could be a bit confusing. Too many ``name``s! I think it's clearer if the variable we're using has nothing to do with the string "name". I've also made the incorrect variable name a typo of the correct one, which ties in with the explanatory text that follows.

On the other hand, the example now differs from those before and after it, so I totally understand if you'd rather not make this change.