### PR TITLE
Activate virtualenv after command prompt restart

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -213,6 +213,8 @@ The error you saw was because we when we deployed to Heroku, we created a new da
     $ heroku run python manage.py migrate
 
     $ heroku run python manage.py createsuperuser
+    
+The command prompt will ask you to choose a username and a password again. These will be your login details on your live website's admin page. Refresh it in your browser, and you're good to go!
 
 You should now be able to see your website in a browser! Congrats :)!
 


### PR DESCRIPTION
My team got quite confused when they had to reopen the command line after doing the Heroku thingies and the next commands weren't working. It would be nice to have a reminder here because activating the virtualenv was ages ago :)