### PR TITLE
activate virtualenv in Start Dj Project

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -14,7 +14,7 @@ The first step towards creating it is to start a new Django project. Basically, 
 The names of some files and directories are very important for Django. You should not rename the files that we are about to create. Moving them to a different place is also not a good idea. Django needs to maintain a certain structure in order to be able to find important things.
 
 > Remember to run everything in the virtualenv. If you don't see a prefix `(myvenv)` in your console you need to activate your virtualenv. We explained how to do that in the __Django installation__ chapter in the __Working with virtualenv__ part. You can do that by typing the following command: `myvenv\Scripts\activate` on Windows or 
-`myvenv/bin/activate` on Mac Os/ Linux.
+`myvenv/bin/activate` on Mac OS / Linux.
 
 
 In console you should run (remember that you don't type `(myvenv) ~/djangogirls$`, OK?):

--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -13,7 +13,9 @@ The first step towards creating it is to start a new Django project. Basically, 
 
 The names of some files and directories are very important for Django. You should not rename the files that we are about to create. Moving them to a different place is also not a good idea. Django needs to maintain a certain structure in order to be able to find important things.
 
-> Remember to run everything in the virtualenv. If you don't see a prefix `(myvenv)` in your console you need to activate your virtualenv. We explained how to do that in the __Django installation__ chapter in the __Working with virtualenv__ part.
+> Remember to run everything in the virtualenv. If you don't see a prefix `(myvenv)` in your console you need to activate your virtualenv. We explained how to do that in the __Django installation__ chapter in the __Working with virtualenv__ part. You can do that by typing the following command: `myvenv\Scripts\activate` on Windows or 
+`myvenv/bin/activate` on Mac Os/ Linux.
+
 
 In console you should run (remember that you don't type `(myvenv) ~/djangogirls$`, OK?):
 

--- a/en/django_templates/README.md
+++ b/en/django_templates/README.md
@@ -16,7 +16,7 @@ To print a variable in Django template, we use double curly brackets with the va
 
     {{ posts }}
 
-Try this in your `blog/templates/blog/post_list.html` template (replace everything between the second `<div></div>` tags with `{{ posts }}` line), save the file and refresh the page to see the results:
+Try this in your `blog/templates/blog/post_list.html` template (replace the second and third pair of `<div></div>` tags with `{{ posts }}` line), save the file and refresh the page to see the results:
 
 ![Figure 13.1](images/step1.png)
 


### PR DESCRIPTION
Attendees usually find it confusing to get back to Django Installation chapter each time they need to activate the virtualenv, so I thought it may be handy to have it here too (as usually this is the chapter they go to directly after Intro to Python).