### PR TITLE
Add pyc files to .gitignore

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -127,6 +127,7 @@ Create a file named `.gitignore` in your `djangogirls` directory with the follow
     staticfiles
     local_settings.py
     db.sqlite3
+    *.pyc
 
 and save it. The dot on the beginning of the file name is important! As you can see, we're now telling Heroku to ignore `local_settings.py` and don't download it, so it's only available on your computer (locally).
 


### PR DESCRIPTION
We should make sure pyc files don't end up in the production environment as this can cause issues since we use a different database locally and on Heroku. 
This adds "*.pyc" to .gitignore so they are excluded.

It's also recommended in the "Getting started with Django" guide at Heroku: 
https://devcenter.heroku.com/articles/getting-started-with-django#gitignore

I have seen some people doing the tutorial having issues with their database, like here:
http://stackoverflow.com/questions/28788452/django-via-heroku-auth-user-error

I had the same issue and I solved it by removing pyc files locally and in production and making sure they are never sent again to Heroku.