### PR TITLE
Fixing Python Version Link

### DIFF
--- a/en/python_installation/README.md
+++ b/en/python_installation/README.md
@@ -39,7 +39,7 @@ Use this command in your console:
 
 ### OS X
 
-You need to go to the website https://www.python.org/downloads/release/python-342/ and download the Python installer:
+You need to go to the website https://www.python.org/downloads/release/python-343/ and download the Python installer:
 
 * download the *Mac OS X 64-bit/32-bit installer* *DMG* file,
 * double click to open it,


### PR DESCRIPTION
Changing URL from 342 to 343 so that it links to version 3.4.3 and not 3.4.2.