### PR TITLE
Advise readers not to use non-ascii characters

### DIFF
--- a/en/django_installation/README.md
+++ b/en/django_installation/README.md
@@ -31,7 +31,7 @@ To create a new `virtualenv`, you need to open the console (we told you about th
 
     C:\Users\Name\djangogirls> C:\Python34\python -m venv myvenv
 
-where `C:\Python34\python` is the directory in which you previously installed Python and `myvenv` is the name of your `virtualenv`. You can use any other name, but stick to lowercase and use no spaces. It is also good idea to keep the name short - you'll be referencing it a lot!
+where `C:\Python34\python` is the directory in which you previously installed Python and `myvenv` is the name of your `virtualenv`. You can use any other name, but stick to lowercase and use no spaces, accents or special characters. It is also good idea to keep the name short - you'll be referencing it a lot!
 
 ### Linux and OS X
 
@@ -97,7 +97,7 @@ Now that you have your `virtualenv` started, you can install Django using `pip`.
     Cleaning up...
 
 on Windows
-> If you get an error when calling pip on Windows platform please check if your project pathname contains spaces (i.e. `C:\Users\User Name\djangogirls`). If it does please consider moving it to another place without spaces (suggestion is: `C:\djangogirls`). After the move please try the above command again.
+> If you get an error when calling pip on Windows platform please check if your project pathname contains spaces, accents or special characters (i.e. `C:\Users\User Name\djangogirls`). If it does please consider moving it to another place without spaces, accents or special characters (suggestion is: `C:\djangogirls`). After the move please try the above command again.
 
 on Linux
 > If you get an error when calling pip on Ubuntu 12.04 please run `python -m pip install -U --force-reinstall pip` to fix the pip installation in the virtualenv.


### PR DESCRIPTION
Yesterday, I was helping my team to set up their laptop for the first DjangoGirls Paris and we encountered an issue during one of the installations. It appears that virtual environments do not work well with paths containing non-ascii characters (in particular, French accents).

So, I updated the tutorial to advise readers to be careful when creating their virtual environment in a directory whose path may contains accents and special characters.