### PR TITLE
Provide alternative runserver command for Windows

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -101,6 +101,11 @@ You need to be in the directory that contains the `manage.py` file (the `djangog
 
     (myvenv) ~/djangogirls$ python manage.py runserver
 
+If you are on Windows and this fails with `UnicodeDecodeError`, use this command instead:
+
+    (myvenv) ~/djangogirls$ python manage.py runserver 0:8000
+
+
 Now all you need to do is check that your website is running - open your browser (Firefox, Chrome, Safari, Internet Explorer or whatever you use) and enter the address:
 
     http://127.0.0.1:8000/


### PR DESCRIPTION
On Windows, hostname may include non-ascii characters encoded by locale-specific encoding.

`runserver` tries to do `gethostbyaddr`, which then fails with `UnicodeDecodeError` as it always try to decode with `utf-8`

Providing IP explicitly (even if it's `0.0.0.0`) enforces Django to skip this resolv, serving as a workaround for [Python's bug #9377](http://bugs.python.org/issue9377).