### PR TITLE
Clarify whether commands should be run on PythonAnywhere

### DIFF
--- a/en/django_orm/README.md
+++ b/en/django_orm/README.md
@@ -12,7 +12,7 @@ It's easiest to learn by example. Let's try this, shall we?
 
 ## Django shell
 
-Open up your console and type this command:
+Open up your local console (not on PythonAnywhere) and type this command:
 
     (myvenv) ~/djangogirls$ python manage.py shell
 

--- a/en/django_urls/README.md
+++ b/en/django_urls/README.md
@@ -12,7 +12,7 @@ Every page on the Internet needs its own URL. This way your application knows wh
 
 ## How do URLs work in Django?
 
-Let's open up the `mysite/urls.py` file and see what it looks like:
+Let's open up the `mysite/urls.py` file in your code editor of choice and see what it looks like:
 
 ```python
 from django.conf.urls import include, url

--- a/en/html/README.md
+++ b/en/html/README.md
@@ -148,7 +148,7 @@ It'd be good to see all this out and live on the Internet, right?  Let's do anot
 
 ### Commit, and push your code up to Github
 
-First off, let's see what files have changed since we last deployed:
+First off, let's see what files have changed since we last deployed (run these commands locally, not on PythonAnywhere):
 
     $ git status
 


### PR DESCRIPTION
While coaching at the Ensenada workshop I received questions from multiple students about whether commands needed to be run on PythonAnywhere.

This pull request provides some suggestions for answering some of these questions before they arise.  I am not particularly satisfied with the wording, but I haven't thought of anything better yet.

A couple alternative solutions:
- Add a section explaining that all commands after the deployment section are to be run in your local console unless it specifically says to run them on PythonAnywhere
- Change the appearance of code sections that should be run on PythonAnywhere (maybe change the color or font) and explain the difference

Feel free to close this pull request in favor of a better solution.

I have never coached students with the Heroku tutorial so I am not sure if these are new problems.