### PR TITLE
Add a bit of security to the "add new post" link

### DIFF
--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -332,6 +332,28 @@ Congratulations! Your application is getting more and more complete!
 
 If you need more information about Django forms you should read the documentation: https://docs.djangoproject.com/en/1.8/topics/forms/
 
+## Security
+
+Being able to create new posts just by clicking a link is awesome! But, right now, anyone that visits your site will be able to post a new blog post and that's probably not something you want. Let's make it so the button shows up for you but not far anyone else.
+
+In `blog/templates/blog/base.html`, find our `page-header` `div` and the anchor tag you put in there earlier. It should look like this:
+
+```html
+<a href="{% url 'post_new' %}" class="top-menu"><span class="glyphicon glyphicon-plus"></span></a>
+```
+
+We're going to add another `{% if %}` tag to this which will make the link only show up for users that are logged into the admin. Right now, that's just you! Change the `<a>` tag to look like this:
+
+```html
+{% if user.is_authenticated %}
+    <a href="{% url 'post_new' %}" class="top-menu"><span class="glyphicon glyphicon-plus"></span></a>
+{% endif %}
+```
+
+This `{% if %}` will cause the link to only be sent to the browser if the user requesting the page is logged in. This doesn't protect the creation of new posts completely, but it's a good first step. We'll cover more security in the extension lessons.
+
+Since you're likely logged in, if you refresh the page, you won't see anything different. Load the page in a new browser or an incognito window, though, and you'll see that the link doesn't show up!
+
 ## One more thing: deploy time!
 
 Let's see if all this works on PythonAnywhere. Time for another deploy!


### PR DESCRIPTION
The link is awesome but, if followers stop at the end of the official tutorial, they have a large hole in their site that allows third-parties to post to their app for them. This is a minimal step to make it more secure for those that don't get to the end of the second tutorial extension.