### PR TITLE
Don't set published_date when creating new post.

### DIFF
--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -221,7 +221,6 @@ def post_new(request):
         if form.is_valid():
             post = form.save(commit=False)
             post.author = request.user
-            post.published_date = timezone.now()
             post.save()
             return redirect('blog.views.post_detail', pk=post.pk)
     else:
@@ -231,7 +230,7 @@ def post_new(request):
 
 Let's see if it works. Go to the page http://127.0.0.1:8000/post/new/, add a `title` and `text`, save it... and voilà! The new blog post is added and we are redirected to `post_detail` page!
 
-You might have noticed that we are setting publish date before saving the post. Later on, we will introduce a _publish button_ in __Django Girls Tutorial: Extensions__.
+You might have noticed that we are not setting publish date at all. Later on, we will introduce a _publish button_ in __Django Girls Tutorial: Extensions__.
 
 That is awesome!
 


### PR DESCRIPTION
Actually, for this code to work well with the first Extentions homework (http://djangogirls.gitbooks.io/django-girls-tutorial-extensions/content/homework/index.html) it's probably best to not set the published_date here. Otherwise it won't be possible to create drafts, except from the admin site.

Sorry for all the back and forth turns with this publish_date thing.