### PR TITLE
Remove `form.save(commit=False)` from tutorial code and text.

### DIFF
--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -189,14 +189,13 @@ We check if the form is valid and if so, we can save it!
 
 ```python
 if form.is_valid():
-    post = form.save(commit=False)
+    post = form.get_updated_model()
     post.author = request.user
     post.published_date = timezone.now()
     post.save()
 ```
 
-Basically, we have two things here: we save the form with `form.save` and we add an author (since there was no `author` field in the `PostForm` and this field is required!). `commit=False` means that we don't want to save `Post` model yet - we want to add author first. Most of the time you will use `form.save()`, without `commit=False`, but in this case, we need to do that.
-`post.save()` will preserve changes (adding author) and a new blog post is created!
+Basically, we have two things here: we get a `post` model containing the new data from the form and we add an author (since there was no `author` field in the `PostForm` and this field is required!), as well as a published date. Then`post.save()` saves the model into the database and a new blog post is created!
 
 Finally, it would be awesome if we can immediatelly go to `post_detail` page for newly created blog post, right? To do that we need one more import:
 
@@ -219,7 +218,7 @@ def post_new(request):
     if request.method == "POST":
         form = PostForm(request.POST)
         if form.is_valid():
-            post = form.save(commit=False)
+            post = form.get_updated_model()
             post.author = request.user
             post.published_date = timezone.now()
             post.save()
@@ -296,7 +295,7 @@ def post_edit(request, pk):
     if request.method == "POST":
         form = PostForm(request.POST, instance=post)
         if form.is_valid():
-            post = form.save(commit=False)
+            post = form.get_updated_model()
             post.author = request.user
             post.published_date = timezone.now()
             post.save()

--- a/es/django_forms/README.md
+++ b/es/django_forms/README.md
@@ -194,12 +194,13 @@ Comprobamos que el formulario es válido y, si es así, ¡lo podemos salvar!
 
 ```python
     if form.is_valid():
-        post = form.save(commit=False)
+        post = form.get_updated_model()
         post.author = request.user
+        post.published_date = timezone.now()
         post.save()
 ```    
 
-Básicamente, tenemos que hacer dos cosas aquí: guardamos el formulario con `form.save` y añadimos un autor (ya que no había ningún campo de `author` en el `PostForm` y este campo es obligatorio). `commit=False` significa que no queremos guardar el modelo `Post` todavía - queremos añadir el autor primero. La mayoría de las veces utilizarás `form.save()`, sin `commit=False`, pero en este caso, tenemos que hacerlo. `post.save()` conservará los cambios (añadiendo a autor) y se creará una nuevo post en el blog.
+Básicamente, tenemos que hacer dos cosas aquí: obtenemos un modelo actualizado con los nuevos datos del formulario y le añadimos un autor (ya que no había ningún campo de `author` en el `PostForm` y este campo es obligatorio), además de la fecha de publicación. A continuación `post.save()` guarda el modelo en la base de datos, y se crea un nuevo post en el blog!
 
 Por último, sería genial si podemos inmediatamente ir a la página `post_detail` del nuevo post de blog, ¿no? Para hacerlo necesitamos importar algo más:
 
@@ -222,8 +223,9 @@ Bien, hablamos mucho, pero probablemente queremos ver como se ve ahora la *vista
         if request.method == "POST":
             form = PostForm(request.POST)
             if form.is_valid():
-                post = form.save(commit=False)
+                post = form.get_updated_model()
                 post.author = request.user
+                post.published_date = timezone.now()
                 post.save()
                 return redirect('blog.views.post_detail', pk=post.pk)
         else:
@@ -298,8 +300,9 @@ Abramos el archivo `blog/views.py` y añadamos al final esta línea:
         if request.method == "POST":
             form = PostForm(request.POST, instance=post)
             if form.is_valid():
-                post = form.save(commit=False)
+                post = form.get_updated_model()
                 post.author = request.user
+                post.published_date = timezone.now()
                 post.save()
                 return redirect('blog.views.post_detail', pk=post.pk)
         else:


### PR DESCRIPTION
Remove `form.save(commit=False)` from tutorial code and text.

Rationale:

While doing the djangogirls tutorial, I noticed that ModelForm.save(commit=False) is given to newcomers as a reasonable way to acquire a form's populated model. This is an antipattern for several reasons:

  - It's counterintuitive. To a newcomer, it's the same as `save(save=no)`. 
  - It's a leaky abstraction. Understanding it requires understanding that the save method does two things: a) prepare the model, and b) save it to the database.
  - It doesn't name its effect or return well.
  - It forces the tutorial to explain why "save" means "not save, not really", while "save()" means "really save, really".

Separately, I've written a Django patch adding a new utility method, `ModelForm.get_updated_model()`, which addresses these issues.

The present patch modifies the django_forms chapter so the new `ModelForm.get_updated_model()` method is used, and the explanation is made clearer.

Changes:

  - used `post = form.get_updated_model()` in forms tutorial code.
  - changed English tutorial text correspondingly.
  - changed Spanish tutorial text correspondingly.
  - updated Spanish tutorial a bit where it lagged behind the English one.

Dependencies:

The present patch depends on a proposed patch to Django. It can only be merged if/when the Django patch is merged and the tutorial is upgraded to a later Django version.

https://github.com/django/django/pull/5105
