### PR TITLE
Add /static to .gitignore and clarify file location

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -40,6 +40,7 @@ Git will track changes to all the files and folders in this directory, but there
 __pycache__
 myvenv
 db.sqlite3
+/static
 .DS_Store
 ```
 

--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -44,7 +44,7 @@ db.sqlite3
 .DS_Store
 ```
 
-And save it as `.gitignore` in the top-level "djangogirls" folder.
+And save it as `.gitignore` in the "djangogirls" folder.
 
 > **Note** The dot at the beginning of the file name is important!  If you're having any difficulty creating it (Macs don't like you to create files that begin with a dot via the Finder, for example), then use the "Save As" feature in your editor, it's bulletproof.
 


### PR DESCRIPTION
This pull request includes two changes:

- Add `/static` to `.gitignore` (see #471)
- Remove "top-level" wording when discussing where to save the `.gitignore` file

One of my students asked me what "top-level" meant and I realized this wording may have been from a time when "mysite" was "djangogirls" so there was a `djangogirls/djangogirls` folder and the top-level one was the root folder.

I'm happy to use rebase to remove one of these commits if desired.