### PR TITLE
Pulled up note about logged out user error message

### DIFF
--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -235,6 +235,10 @@ You might have noticed that we are setting publish date before saving the post. 
 
 That is awesome!
 
+> As we have recently used the Django admin interface the system currently thinks we are logged in. There are a few situations that could lead to us being logged out (closing the browser, restarting the DB etc.). If you find that you are getting errors creating a post referring to a lack of a logged in user, head to the admin page http://127.0.0.1:8000/admin and log in again. This will fix the issue temporarily. There is a permanent fix awaiting you in the __Homework: add security to your website!__ chapter after the main tutorial.
+
+![Logged in error](images/post_create_error.png)
+
 
 ## Form validation
 
@@ -245,10 +249,6 @@ Try to save the form without `title` and `text`. Guess, what will happen!
 ![Form validation](images/form_validation2.png)
 
 Django is taking care of validating that all the fields in our form are correct. Isn't it awesome?
-
-> As we have recently used the Django admin interface the system currently thinks we are logged in. There are a few situations that could lead to us being logged out (closing the browser, restarting the DB etc.). If you find that you are getting errors creating a post referring to a lack of a logged in user, head to the admin page http://127.0.0.1:8000/admin and log in again. This will fix the issue temporarily. There is a permanent fix awaiting you in the __Homework: add security to your website!__ chapter after the main tutorial.
-
-![Logged in error](images/post_create_error.png)
 
 
 ## Edit form


### PR DESCRIPTION
because this error could happen right after trying to save the form. Right now users will not go on reading the next section about form validation when this error is popping up and therefore will not see its solution.