### PR TITLE
Fixing command line

### DIFF
--- a/pt/django_start_project/README.md
+++ b/pt/django_start_project/README.md
@@ -23,7 +23,7 @@ No console, você deve executar (Lembre-se de que você não pode digitar `~/dja
 
 no Windows:
 
-    (myvenv) C:\Users\Name\djangogirls> django-admin.py startproject mysite .
+    (myvenv) C:\Users\Name\djangogirls> python myvenv\Scripts\django-admin.py startproject mysite .
     
 
 `Django-admin` é um script que irá criar os diretórios e arquivos para você. Agora, você deve ter um diretório estrutura que se parece com isso:


### PR DESCRIPTION
`(myvenv) C:\Users\Name\djangogirls> django-admin.py startproject mysite .`
- [en] Kept opening up a dialog box "Open with" to select a web browser.
I've read in stackoverflow that it must be a virtual environment bug.
- [pt-br] Abria um pop-up "Abrir com" para selecionar um browser.
Li no stackoverflow que era um bug do ambiente virtual.

`(myvenv) C:\Users\Name\djangogirls> python myvenv\Scripts\django-admin.py startproject mysite .`
- [en] worked fine.
- [pt-br] funcionou perfeitamente.