### PR TITLE
Updated portuguese tutorial to point to Django 1.8.

### DIFF
--- a/pt/deploy/README.md
+++ b/pt/deploy/README.md
@@ -196,7 +196,7 @@ Assim como fez em seu próprio computador, você pode criar um virtualenv na Pyt
     (mvenv)20:20 ~ $  pip install django whitenoise
     Collecting django
     [...]
-    Successfully installed django-1.8.2 whitenoise-2.0
+    Successfully installed django-1.8.5 whitenoise-2.0
     
 
 <!--TODO: think about using requirements.txt instead of pip install.-->

--- a/pt/django_admin/README.md
+++ b/pt/django_admin/README.md
@@ -43,6 +43,6 @@ Certifique-se que pelo menos duas ou três postagens (mas não todas) têm a dat
 
  [3]: images/edit_post3.png
 
-Se você quiser saber mais sobre o Django admin, você deve conferir a documentação do Django: https://docs.djangoproject.com/en/1.6/ref/contrib/admin/
+Se você quiser saber mais sobre o Django admin, você deve conferir a documentação do Django: https://docs.djangoproject.com/en/1.8/ref/contrib/admin/
 
 Este é provavelmente um bom momento para tomar um café (ou chocolate) ou algo para comer para repora as energias. Você criou seu primeiro modelo de Django - você merece um pouco de descanso!

--- a/pt/django_forms/README.md
+++ b/pt/django_forms/README.md
@@ -338,7 +338,7 @@ Sinta-se livre para mudar o título ou o texto e salvar as mudanças!
 
 Parabéns! Sua aplicação está ficando cada vez mais completa!
 
-Se você precisar de mais informações sobre formulários do Django você deve ler a documentação: https://docs.djangoproject.com/en/1.6/topics/forms/
+Se você precisar de mais informações sobre formulários do Django você deve ler a documentação: https://docs.djangoproject.com/en/1.8/topics/forms/
 
 ## Mais uma coisa: hora de implantar!
 

--- a/pt/django_installation/README.md
+++ b/pt/django_installation/README.md
@@ -93,10 +93,10 @@ Ok, nós temos todas as dependências importantes no lugar. Finalmente podemos i
 
 ## Instalando o Django
 
-Agora que você tem a sua `virtualenv` iniciado, você pode instalar Django usando `pip`. No console, execute `pip install django==1.7.1` (Perceba que usamos um duplo sinal de igual: `==`).
+Agora que você tem a sua `virtualenv` iniciado, você pode instalar Django usando `pip`. No console, execute `pip install django==1.8.5` (Perceba que usamos um duplo sinal de igual: `==`).
 
-    (myvenv) ~$ pip install django==1.8
-    Downloading/unpacking django==1.8
+    (myvenv) ~$ pip install django==1.8.5
+    Downloading/unpacking django==1.8.5
     Installing collected packages: django
     Successfully installed django
     Cleaning up...

--- a/pt/django_urls/README.md
+++ b/pt/django_urls/README.md
@@ -120,4 +120,4 @@ Não tem mais "It Works!' mais ein? Não se preocupe, é só uma página de erro
 
 Você pode ler que não há **no attribute 'post_list'**. O *post_list* te lembra alguma coisa? Isto é como chamamos o nosso view! Isso significa que está tudo no lugar, só não criamos nossa *view* ainda. Não se preocupe, nós chegaremos lá.
 
-> Se você quer saber mais sobre Django URLconfs, veja a documentação oficial: https://docs.djangoproject.com/en/1.7/topics/http/urls/
+> Se você quer saber mais sobre Django URLconfs, veja a documentação oficial: https://docs.djangoproject.com/en/1.8/topics/http/urls/

--- a/pt/django_views/README.md
+++ b/pt/django_views/README.md
@@ -35,4 +35,4 @@ Outro erro! Leia o que está acontecendo agora:
 
 Esta é fácil: *TemplateDoesNotExist*. Vamos corrigir este bug e criar um modelo no próximo capítulo!
 
-> Aprenda mais sobre as views do Django lendo a documentação oficial: https://docs.djangoproject.com/en/1.6/topics/http/views/
+> Aprenda mais sobre as views do Django lendo a documentação oficial: https://docs.djangoproject.com/en/1.8/topics/http/views/

--- a/pt/dynamic_data_in_templates/README.md
+++ b/pt/dynamic_data_in_templates/README.md
@@ -67,6 +67,6 @@ def post_list(request):
 
 Feito! Hora de voltar para o nosso template e exibir essa QuerySet!
 
-Se quiser ler mais sobre QuerySets no Django você deve dar uma olhada aqui: https://docs.djangoproject.com/en/1.7/ref/models/querysets/
+Se quiser ler mais sobre QuerySets no Django você deve dar uma olhada aqui: https://docs.djangoproject.com/en/1.8/ref/models/querysets/
 
  [2]: /django_orm/README.html


### PR DESCRIPTION
The portuguese tutorial use different versions of Django across files.
This patch updated all the references to current stable version 1.8.5.