### PR TITLE
Corrigindo erro de typo.

### DIFF
--- a/pt/deploy/README.md
+++ b/pt/deploy/README.md
@@ -12,7 +12,7 @@ O outro serviço externo que usaremos é [GitHub][2], que é um serviço de hosp
 
  [2]: http://www.github.com
 
-Usaremos o GitHub como um trampolim para transportar nosso código para o PythinAnywhere.
+Usaremos o GitHub como um trampolim para transportar nosso código para o PythonAnywhere.
 
 # Git
 


### PR DESCRIPTION
PythinAnywhere para PythonAnywhere.