### PR TITLE
Add note to create a branch before starting to edit in contributing README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Either use the Github app for your operating system (mentioned above) or `git` c
 
     git clone git@github.com:yourgithubusername/tutorial.git
 
+Then, create a branch for your new changes to sit in. It helps to call the branch something related to the changes you are going to make.
+
+    git checkout -b contributing
+
 Download the [Gitbook Editor](https://github.com/GitbookIO/editor-legacy/releases) app to your computer.
 
 Then you can open the tutorial in Gitbook Editor (*File* > *Open book*).


### PR DESCRIPTION
The existing documentation referenced a `contributing` branch in the git output, but creating this branch was never detailed in the instructions. I've confirmed that GitBook doesn't appear to do this for you, so I've added it under the `git clone` command. 

I tried to keep the new copy in line with the current tone, but I'm more than happy to accept changes to make it match better. 