### PR TITLE
Fixed include paths.

### DIFF
--- a/hu/code_editor/README.md
+++ b/hu/code_editor/README.md
@@ -4,4 +4,4 @@ Nemsokára megírod a kód első sorát, itt az ideje letölteni egy kódszerkes
 
 > **Megjegyzés:** Lehet, hogy ezt már megtetted a Telepítés fejezet olvasása során - ha igen, ugorj előre a következő fejezetre!
 
-{% include "code_editor/instructions.md" %}
+{% include "/code_editor/instructions.md" %}

--- a/hu/deploy/README.md
+++ b/hu/deploy/README.md
@@ -22,7 +22,7 @@ A Git egy "version control system" (VCS, magyarul verziókezelő rendszer), amit
 
 > **Megjegyzés** Ha már követted a korábbi telepítési utasításokat, ezt a pontot átugorhatod és kezdheted kialakítani a saját Git csomagtáradat!
 
-{% include "deploy/install_git.md" %}
+{% include "/deploy/install_git.md" %}
 
 ## Készítsünk Git repository-t
 
@@ -129,7 +129,7 @@ A forráskódod most már fent van a GitHubon. Menj és nézd meg! Láthatod hog
 
 > **Megjegyzés** Valószínűleg már létrehoztál egy PythonAnywhere fiókot korábban a telepítés során - ha így van, ezt nem kell újból megtenned.
 
-{% include "deploy/signup_pythonanywhere.md" %}
+{% include "/deploy/signup_pythonanywhere.md" %}
 
 ## Forráskód letöltése a PythonAnywhere-be
 

--- a/hu/django_installation/README.md
+++ b/hu/django_installation/README.md
@@ -2,4 +2,4 @@
 
 > **Megjegyzés** Ha elvégezted a legelső, Installáció című fejezetet, már túlvagy ezen - ugorj a következő fejezetre!
 
-{% include "django_installation/instructions.md" %}
+{% include "/django_installation/instructions.md" %}

--- a/hu/installation/README.md
+++ b/hu/installation/README.md
@@ -14,19 +14,19 @@ A workshopon egy blogot fogsz elkészíteni. Ehhez el kell végezned néhány te
 
 # A Python telepítése
 
-{% include "python_installation/instructions.md" %}
+{% include "/python_installation/instructions.md" %}
 
 # Virtuális környezet létrehozása és a Django telepítése
 
-{% include "django_installation/instructions.md" %}
+{% include "/django_installation/instructions.md" %}
 
 # Kódszerkesztő telepítése
 
-{% include "code_editor/instructions.md" %}
+{% include "/code_editor/instructions.md" %}
 
 # A Git telepítése
 
-{% include "deploy/install_git.md" %}
+{% include "/deploy/install_git.md" %}
 
 # GitHub fiók létrehozása
 
@@ -34,7 +34,7 @@ Menj a [GitHub.com](http://www.github.com) oldalra, és hozz létre egy új, ing
 
 # PythonAnywhere felhasználó létrehozása
 
-{% include "deploy/signup_pythonanywhere.md" %}
+{% include "/deploy/signup_pythonanywhere.md" %}
 
 # Kezdheted az olvasást
 

--- a/hu/python_installation/README.md
+++ b/hu/python_installation/README.md
@@ -10,4 +10,4 @@ A Pythont a 80-as évek végén alkották meg, és a fő cél az volt, hogy ne c
 
 > **Megjegyzés** Ha már elvégezted az Installáció fejezetet, nem kell újra megtenned - ugorj a következő fejezetre!
 
-{% include "python_installation/instructions.md" %}
+{% include "/python_installation/instructions.md" %}


### PR DESCRIPTION
All include paths should be absolute. English version of tutorial has it right, but for some reason, in crowdin there're relative paths...