### PR TITLE
fix `TemplateSyntaxError at /post/2/edit/` `Invalid block tag: 'raw', expected 'endblock'`

### DIFF
--- a/hu/django_forms/README.md
+++ b/hu/django_forms/README.md
@@ -142,7 +142,7 @@ Rendben, nézzük, hogy néz ki a HTML kód a `post_edit.html`-ben:
 
 {% block content %}
     <h1>New post</h1>
-    <form method="POST" class="post-form">{% raw %}{% csrf_token %}{% endraw %}
+    <form method="POST" class="post-form">{% csrf_token %}
         {{ form.as_p }}
         <button type="submit" class="save btn btn-default">Save</button>
     </form>


### PR DESCRIPTION
fix by removing tags raw and endraw from fenced html block