### PR TITLE
Broken link: updated Django carrots to the repo

### DIFF
--- a/en/whats_next/README.md
+++ b/en/whats_next/README.md
@@ -19,7 +19,7 @@ Later on, you can try the resources listed below. They're all very recommended!
 - [New Coder tutorials](http://newcoder.io/tutorials/)
 - [Code Academy Python course](http://www.codecademy.com/en/tracks/python)
 - [Code Academy HTML & CSS course](http://www.codecademy.com/tracks/web)
-- [Django Carrots tutorial](http://django.carrots.pl/en/)
+- [Django Carrots tutorial](https://github.com/ggcarrots/django-carrots)
 - [Learn Python The Hard Way book](http://learnpythonthehardway.org/book/)
 - [Getting Started With Django video lessons](http://gettingstartedwithdjango.com/)
 - [Two Scoops of Django: Best Practices for Django 1.8 book](http://twoscoopspress.com/products/two-scoops-of-django-1-8)


### PR DESCRIPTION
There are instructions in the repo for going through the tutorial, so it should be a good replacement for the website :).