### PR TITLE
Added possible error message for Windows 10 users

### DIFF
--- a/en/django_installation/README.md
+++ b/en/django_installation/README.md
@@ -58,7 +58,16 @@ The command above will create a directory called `myvenv` (or whatever name you 
 
     C:\Users\Name\djangogirls> myvenv\Scripts\activate
 
-on Windows, or:
+on Windows, 
+
+> __NOTE:__ on Windows 10 you might get an error in the Windows PowerShell says `execution of scripts is disabled on this system`. In those cases open another Windows PowerShell and Run as Administrator try doing this before continue:
+
+>     C:\WINDOWS\system32> Set-ExecutionPolicy -ExecutionPolicy RemoteSigned
+
+>     Execution Policy Change
+>     The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at http://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy? [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"): A
+
+or:
 
     ~/djangogirls$ source myvenv/bin/activate
 


### PR DESCRIPTION
Windows 10 computer might receive message “execution of scripts is
disabled on this system.” message to prevent users to continue or work
in venv. To correct this error, the user needs to set execution policy
to apply to All.