### PR TITLE
Update python install instructions for Fedora

### DIFF
--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -33,7 +33,7 @@ Type this command into your console:
 
 Use this command in your console:
 
-    $ sudo yum install python3.4
+    $ sudo yum install python3
 
 
 #### Fedora (22+)


### PR DESCRIPTION
On Fedora 20 and Fedora 21, doing 'yum install python3.4' as currently documented, 
returns 'No package python3.4 available.'.
Doing 'yum install python3' installs python3.4.x