### PR TITLE
Edit to WSGI configuration file

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -267,6 +267,7 @@ if path not in sys.path:
 os.environ['DJANGO_SETTINGS_MODULE'] = 'mysite.settings'
 
 from django.core.wsgi import get_wsgi_application
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "prompt.settings")
 from whitenoise.django import DjangoWhiteNoise
 application = DjangoWhiteNoise(get_wsgi_application())
 ```


### PR DESCRIPTION
As per https://github.com/evansd/whitenoise/issues/31

Error from PythonAnywhere 
https://www.pythonanywhere.com/user/<USER NAME>/files/var/log/<USER NAME>.pythonanywhere.com.error.log
2016-01-07 13:17:08,392 :    from whitenoise.django import DjangoWhiteNoise
2016-01-07 13:17:08,392 :ImportError: No module named 'whitenoise'