### PR TITLE
Change link to Github plugin

### DIFF
--- a/book.json
+++ b/book.json
@@ -6,7 +6,7 @@
     },
 
     "plugins": [
-        "heading-anchors", "ga", "richquotes@0.0.7", "edit-link@2.0.0"
+        "heading-anchors", "ga", "richquotes@0.0.7", "github"
     ],
     "pluginsConfig": {
         "ga": {
@@ -15,9 +15,9 @@
         "richquotes" : {
             "default" : false
         },
-        "edit-link": {
-            "base": "https://github.com/djangogirls/tutorial/edit/master",
-            "label": "Edit This Page"
+        "pluginsConfig": {
+        "github": {
+            "url": "https://github.com/DjangoGirls/tutorial"
         }
     },
 


### PR DESCRIPTION
To prevent contributors to make micro PR to fix typo, we could replace the "edit this page on github" link by a social button linking to this github repository (example [here](https://djangogirls.gitbooks.io/django-girls-tutorial-extensions/content/)).
The button is a bit small but don't forget that the introduction have a paragraph about on how to contribute with a link to the repository and contributors guidelines :wink: 