### PR TITLE
Remove need for whitenoise and collectstatic

### DIFF
--- a/en/css/README.md
+++ b/en/css/README.md
@@ -38,7 +38,7 @@ Finally we will take a closer look at these things we've been calling __static f
 
 ### Where to put static files for Django
 
-As you saw when we ran `collectstatic` on the server, Django already knows where to find the static files for the built-in "admin" app. Now we just need to add some static files for our own app, `blog`. 
+Django already knows where to find the static files for the built-in "admin" app. Now we just need to add some static files for our own app, `blog`.
 
 We do that by creating a folder called `static` inside the blog app:
 
@@ -66,7 +66,7 @@ Time to write some CSS! Open up the `blog/static/css/blog.css` file in your code
 
 We won't be going too deep into customizing and learning about CSS here. It's pretty easy and you can learn it on your own after this workshop. There is a recommendation for a free course to learn more at the end of this page.
 
-But let's do at least a little. Maybe we could change the color of our header? 
+But let's do at least a little. Maybe we could change the color of our header?
 To understand colors, computers use special codes. These codes start with `#` followed by 6 letters (A-F) and numbers (0-9). For example, the code for blue is `#0000FF`. You can find the color codes for many colors here: http://www.colorpicker.com/. You may also use [predefined colors](http://www.w3schools.com/cssref/css_colornames.asp), such as `red` and `green`.
 
 In your `blog/static/css/blog.css` file you should add the following code:
@@ -79,7 +79,7 @@ h1 a {
 
 `h1 a` is a CSS Selector. This means we're applying our styles to any `a` element inside of an `h1` element. So when we have something like: `<h1><a href="">link</a></h1>` the `h1 a` style will apply. In this case, we're telling it to change its color to `#FCA205`, which is orange. Of course, you can put your own color here!
 
-In a CSS file we determine styles for elements in the HTML file. The first way we identify elements is with the element name. You might remember these as tags from the HTML section. Things like `a`, `h1`, and `body` are all examples of element names. 
+In a CSS file we determine styles for elements in the HTML file. The first way we identify elements is with the element name. You might remember these as tags from the HTML section. Things like `a`, `h1`, and `body` are all examples of element names.
 We also identify elements by the attribute `class` or the attribute `id`. Class and id are names you give the element by yourself. Classes define groups of elements, and ids point to specific elements. For example, you could identify the following tag by using the tag name `a`, the class `external_link`, or the id `link_to_wiki_page`:
 
 ```html
@@ -94,13 +94,13 @@ Then, we need to also tell our HTML template that we added some CSS. Open the `b
 {% load staticfiles %}
 ```
 
-We're just loading static files here :). 
+We're just loading static files here :).
 Between the `<head>` and `</head>`, after the links to the Bootstrap CSS files add this line:
 
 ```html
 <link rel="stylesheet" href="{% static 'css/blog.css' %}">
 ```
-The browser reads the files in the order they're given, so we need to make sure this is in the right place. Otherwise the code in our file may override code in Bootstrap files. 
+The browser reads the files in the order they're given, so we need to make sure this is in the right place. Otherwise the code in our file may override code in Bootstrap files.
 We just told our template where our CSS file is located.
 
 Your file should now look like this:
@@ -276,10 +276,10 @@ Save those files and refresh your website.
 
 ![Figure 14.4](images/final.png)
 
-Woohoo! Looks awesome, right? 
-Look at the code we just pasted to find the places where we added classes in the HTML and used them in the CSS. Where would you make the change if you wanted the date to be turquoise? 
+Woohoo! Looks awesome, right?
+Look at the code we just pasted to find the places where we added classes in the HTML and used them in the CSS. Where would you make the change if you wanted the date to be turquoise?
 
-Don't be afraid to tinker with this CSS a little bit and try to change some things. Playing with the CSS can help you understand what the different things are doing. If you break something, don't worry, you can always undo it! 
+Don't be afraid to tinker with this CSS a little bit and try to change some things. Playing with the CSS can help you understand what the different things are doing. If you break something, don't worry, you can always undo it!
 
 We really recommend taking this free online [Codeacademy HTML & CSS course](http://www.codecademy.com/tracks/web). It can help you learn all about making your websites prettier with CSS.
 

--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -167,46 +167,16 @@ Installing setuptools, pip...done.
 
 $ source myvenv/bin/activate
 
-(myvenv) $  pip install django whitenoise
+(myvenv) $  pip install django
 Collecting django
 [...]
-Successfully installed django-1.9 whitenoise-2.0
+Successfully installed django-1.9
 ```
 
 
 > **Note** The `pip install` step can take a couple of minutes.  Patience, patience!  But if it takes more than 5 minutes, something is wrong.  Ask your coach.
 
 <!--TODO: think about using requirements.txt instead of pip install.-->
-
-
-### Collecting static files.
-
-Were you wondering what the "whitenoise" thing was?  It's a tool for serving so-called "static files". Static files are the files that don't regularly change or don't run programming code, such as HTML or CSS files. They work differently on servers compared to on our own computer and we need a tool like "whitenoise" to serve them.
-
-We'll find out a bit more about static files later in the tutorial, when we edit the CSS for our site.
-
-For now we just need to run an extra command called `collectstatic`, on the server. It tells Django to gather up all the static files it needs on the server. At the moment these are mostly files that make the admin site look pretty.
-
-    (myvenv) $ python manage.py collectstatic
-
-    You have requested to collect static files at the destination
-    location as specified in your settings:
-
-        /home/edith/my-first-blog/static
-
-    This will overwrite existing files!
-    Are you sure you want to do this?
-
-    Type 'yes' to continue, or 'no' to cancel: yes
-
-Type "yes", and away it goes!  Don't you love making computers print out pages and pages of impenetrable text?  I always make little noises to accompany it. Brp, brp brp...
-
-    Copying '/home/edith/my-first-blog/myvenv/lib/python3.4/site-packages/django/contrib/admin/static/admin/js/actions.min.js'
-    Copying '/home/edith/my-first-blog/myvenv/lib/python3.4/site-packages/django/contrib/admin/static/admin/js/inlines.min.js'
-    [...]
-    Copying '/home/edith/my-first-blog/myvenv/lib/python3.4/site-packages/django/contrib/admin/static/admin/css/changelists.css'
-    Copying '/home/edith/my-first-blog/myvenv/lib/python3.4/site-packages/django/contrib/admin/static/admin/css/base.css'
-    62 static files copied to '/home/edith/my-first-blog/static'.
 
 
 ### Creating the database on PythonAnywhere
@@ -227,7 +197,7 @@ We can initialise the database on the server just like we did the one on your ow
 
 ## Publishing our blog as a web app
 
-Now our code is on PythonAnywhere, our virtualenv is ready, the static files are collected, and the database is initialised. We're ready to publish it as a web app!
+Now our code is on PythonAnywhere, our virtualenv is ready, and the database is initialised. We're ready to publish it as a web app!
 
 Click back to the PythonAnywhere dashboard by clicking on its logo, and go click on the **Web** tab. Finally, hit **Add a new web app**.
 
@@ -267,14 +237,16 @@ if path not in sys.path:
 os.environ['DJANGO_SETTINGS_MODULE'] = 'mysite.settings'
 
 from django.core.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
-application = DjangoWhiteNoise(get_wsgi_application())
+from django.contrib.staticfiles.handlers import StaticFilesHandler
+application = StaticFilesHandler(get_wsgi_application())
 ```
 
 > **Note** Don't forget to substitute in your own username where it says `<your-username>`
-> **Note** In line three, we make sure Pyhthon anywhere knows how to find our application. It is very important that this path name is correct, and especially that there are no extra spaces here. Otherwise you will see an "ImportError" in the error log.
+> **Note** In line three, we make sure Python anywhere knows how to find our application. It is very important that this path name is correct, and especially that there are no extra spaces here. Otherwise you will see an "ImportError" in the error log.
 
-This file's job is to tell PythonAnywhere where our web app lives and what the Django settings file's name is. It also sets up the "whitenoise" static files tool.
+This file's job is to tell PythonAnywhere where our web app lives and what the Django settings file's name is.
+
+The `StaticFilesHandler` is for dealing with our CSS. This is taken care of automatically for you during local development by the `runserver` command. We'll find out a bit more about static files later in the tutorial, when we edit the CSS for our site.
 
 Hit **Save** and then go back to the **Web** tab.
 
@@ -285,7 +257,7 @@ We're all done! Hit the big green **Reload** button and you'll be able to go vie
 
 If you see an error when you try to visit your site, the first place to look for some debugging info is in your **error log**. You'll find a link to this on the PythonAnywhere [Web tab](https://www.pythonanywhere.com/web_app_setup/). See if there are any error messages in there; the most recent ones are at the bottom. Common problems include:
 
-- Forgetting one of the steps we did in the console: creating the virtualenv, activating it, installing Django into it, running collectstatic, migrating the database.
+- Forgetting one of the steps we did in the console: creating the virtualenv, activating it, installing Django into it, migrating the database.
 
 - Making a mistake in the virtualenv path on the Web tab -- there will usually be a little red error message on there, if there is a problem.
 

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -391,8 +391,6 @@ $ cd my-first-blog
 $ source myvenv/bin/activate
 (myvenv)$ git pull
 [...]
-(myvenv)$ python manage.py collectstatic
-[...]
 ```
 
 * Finally, hop on over to the [Web tab](https://www.pythonanywhere.com/web_app_setup/) and hit **Reload**.

--- a/en/extend_your_application/README.md
+++ b/en/extend_your_application/README.md
@@ -172,8 +172,6 @@ $ cd my-first-blog
 $ source myvenv/bin/activate
 (myvenv)$ git pull
 [...]
-(myvenv)$ python manage.py collectstatic
-[...]
 ```
 
 * Finally, hop on over to the [Web tab](https://www.pythonanywhere.com/web_app_setup/) and hit **Reload**.

--- a/en/html/README.md
+++ b/en/html/README.md
@@ -182,8 +182,6 @@ $ cd ~/my-first-blog
 $ source myvenv/bin/activate
 (myvenv)$ git pull
 [...]
-(myvenv)$ python manage.py collectstatic
-[...]
 ```
 
 And watch your code get downloaded. If you want to check that it's arrived, you can hop over to the **Files tab** and view your code on PythonAnywhere.


### PR DESCRIPTION
Enabling the same WSGI middleware that is used by runserver allows us to simplify the static files process, and remove a bunch of steps.

As discussed in #641 