### PR TITLE
Changes to Models and Deploy Chapter

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -302,5 +302,7 @@ And remember, your coach is here to help!
 
 The default page for your site should say "Welcome to Django", just like it does on your local computer. Try adding `/admin/` to the end of the URL, and you'll be taken to the admin site. Log in with the username and password, and you'll see you can add new Posts on the server.
 
+Once you have a few posts created, you can go back to your local setup (not PythonAnywhere). From here you should work on your local setup to make changes. This is a common workflow in Web development (make changes locally, push those changes to GitHub, pull your changes down to your live Web server). This allows you to work and expirement without breaking your live Web site. Pretty cool, huh?
+
 
 Give yourself a *HUGE* pat on the back! Server deployments are one of the trickiest parts of web development and it often takes people several days before they get them working. But you've got your site live, on the real Internet, just like that!

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -148,6 +148,8 @@ What about `def publish(self):`? It is exactly the `publish` method we were talk
 
 Methods often `return` something. There is an example of that in the `__str__` method. In this scenario, when we call `__str__()` we will get a text (**string**) with a Post title.
 
+Also notice that both `def publish(self):`, and `def __str__(self):` are indented inside our class. Because Python is sensitive to whitespace, we need to indent our methods inside the class. Otherwise, the methods won't belong to the class, and you can get some unexpected behavior.
+
 If something is still not clear about models, feel free to ask your coach! We know it is complicated, especially when you learn what objects and functions are at the same time. But hopefully it looks slightly less magic for you now!
 
 ### Create tables for models in your database


### PR DESCRIPTION
In the Models chapter, I noticed participants of the PDX event this previous weekend seeing their posts with the title "Post object." It turned out to be an indentation error. I wanted to make it more clear that the methods needed to be indented inside the class to help future participants.

In the Deploy chapter, it seemed a little confusing to not explain that we would be moving back to our local environment to make changes. One participant made manual changes to her GitHub repo, which was confusing for her when she couldn't push without pulling changes down locally first. I thought this note might help.