### PR TITLE
Change python version in a link for OS X

### DIFF
--- a/ru/python_installation/instructions.md
+++ b/ru/python_installation/instructions.md
@@ -43,7 +43,7 @@ Django написан на Python. Нам нужен Python, чтобы сдел
 
 ### OS X
 
-Тебе нужно перейти по ссылке https://www.python.org/downloads/release/python-342/ и скачать дистрибутив Python:
+Тебе нужно перейти по ссылке https://www.python.org/downloads/release/python-343/ и скачать дистрибутив Python:
 
   * Скачай файл *Mac OS X 64-bit/32-bit installer*,
   * Сделай двойной щелчок на *python-3.4.3-macosx10.6.pkg* для запуска установщика.


### PR DESCRIPTION
For some reason everything here is about 3.4.3, but link was pointed to 3.4.2

I didn't change 59th line, but somehow it marked as changed as well :whale: 