### PR TITLE
Make missing view function error more accurate for 1.9

### DIFF
--- a/en/django_urls/README.md
+++ b/en/django_urls/README.md
@@ -111,12 +111,12 @@ As you can see, we're now assigning a `view` called `post_list` to `^$` URL. Thi
 
 The last part `name='post_list'` is the name of the URL that will be used to identify the view. This can be the same as the name of the view but it can also be something completely different. We will be using the named URLs later in the project so it is important to name each URL in the app. We should also try to keep the names of URLs unique and easy to remember.
 
-Everything all right? Open http://127.0.0.1:8000/ in your browser to see the result.
+If you try to visit http:127.0.0.1:8000/ now, then you'll find some sort of 'web page not available' message. Take a look at your server console window.
 
-![Error](images/error1.png)
+```bash
+AttributeError: 'module' object has no attribute 'post_list'
+```
 
-There is no "It works" anymore, huh? Don't worry, it's just an error page, nothing to be scared of! They're actually pretty useful:
-
-You can read that there is __no attribute 'post_list'__. Is *post_list* reminding you of anything? This is what we called our view! This means that everything is in place but we just haven't created our *view* yet. No worries, we will get there.
+It's not running anymore, huh? It's telling you that there is __no attribute 'post_list'__. That's the name of the *view* that Django is trying to find and use, but we haven't created it yet. No worries, we will get there.
 
 > If you want to know more about Django URLconfs, look at the official documentation: https://docs.djangoproject.com/en/1.9/topics/http/urls/

--- a/en/django_views/README.md
+++ b/en/django_views/README.md
@@ -33,6 +33,6 @@ Another error! Read what's going on now:
 
 ![Error](images/error.png)
 
-This one is easy: *TemplateDoesNotExist*. Let's fix this bug and create a template in the next chapter!
+There is no "It works" anymore, huh? Don't worry, it's just an error page, nothing to be scared of! They're actually pretty useful.  You can read that *TemplateDoesNotExist*. This one is easy: Let's fix this bug and create a template in the next chapter!
 
 > Learn more about Django views by reading the official documentation: https://docs.djangoproject.com/en/1.9/topics/http/views/


### PR DESCRIPTION
Looks like initialisation now tries to import view functions at server start, so you don't get to the DEBUG = True style error page any more. I've changed this, but kept the comments about friendly error pages elsewhere.