### PR TITLE
Update README.md

### DIFF
--- a/en/django_templates/README.md
+++ b/en/django_templates/README.md
@@ -86,7 +86,7 @@ $ git pull
 [...]
 ```
 
-* Finally, hop on over to the [Web tab](https://www.pythonanywhere.com/web_app_setup/) and hit **Reload** on your web app. Your update should be live!
+* Finally, hop on over to the [Web tab](https://www.pythonanywhere.com/web_app_setup/) and hit **Reload** on your web app. Your update should be live! If the blog posts on your PythonAnywhere site don't match the posts appearing on the blog hosted on your local server - that's OK. The databases on your local computer and Python Anywhere don't sync with the rest of your files.
 
 
 Congrats! Now go ahead and try adding a new post in your Django admin (remember to add published_date!) Make sure you are in the Django admin for your pythonanywhere site, https://www.yourname.pythonanywhere.com/admin. Then refresh your page to see if the post appears there.


### PR DESCRIPTION
We were all confused at the end of this step because it was the first time the local server 127.0.0.1:8000 didn't match username.pythonanywhere.com, since we made changes to the local database that were not synced with the database stored on Python Anywhere. To prevent the same panic in others, we thought it would be helpful to add a note that the two sites may not match - and that's OK!