### PR TITLE
Install latest release of Django 1.9

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -167,7 +167,7 @@ Installing setuptools, pip...done.
 
 $ source myvenv/bin/activate
 
-(myvenv) $  pip install "django==1.9.*"
+(myvenv) $  pip install django~=1.9.0
 Collecting django
 [...]
 Successfully installed django-1.9

--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -167,7 +167,7 @@ Installing setuptools, pip...done.
 
 $ source myvenv/bin/activate
 
-(myvenv) $  pip install django==1.9
+(myvenv) $  pip install "django==1.9.*"
 Collecting django
 [...]
 Successfully installed django-1.9

--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -90,9 +90,9 @@ OK, we have all important dependencies in place. We can finally install Django!
 
 ## Installing Django
 
-Now that you have your `virtualenv` started, you can install Django using `pip`. In the console, run `pip install "django==1.9.*"` (note that we use a double equal sign: `==`).
+Now that you have your `virtualenv` started, you can install Django using `pip`. In the console, run `pip install django~=1.9.0` (note that we use a double equal sign: `==`).
 
-    (myvenv) ~$ pip install "django==1.9.*"
+    (myvenv) ~$ pip install django~=1.9.0
     Downloading/unpacking django==1.9
     Installing collected packages: django
     Successfully installed django
@@ -104,7 +104,7 @@ on Windows
 on Windows 8 and Windows 10
 > Your command line might freeze after when you try to install Django. If this happens, instead of the above command use:
 
->     C:\Users\Name\djangogirls> python -m pip install "django==1.9.*"
+>     C:\Users\Name\djangogirls> python -m pip install django~=1.9.0
 
 on Linux
 > If you get an error when calling pip on Ubuntu 12.04 please run `python -m pip install -U --force-reinstall pip` to fix the pip installation in the virtualenv.

--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -90,9 +90,9 @@ OK, we have all important dependencies in place. We can finally install Django!
 
 ## Installing Django
 
-Now that you have your `virtualenv` started, you can install Django using `pip`. In the console, run `pip install django==1.9` (note that we use a double equal sign: `==`).
+Now that you have your `virtualenv` started, you can install Django using `pip`. In the console, run `pip install "django==1.9.*"` (note that we use a double equal sign: `==`).
 
-    (myvenv) ~$ pip install django==1.9
+    (myvenv) ~$ pip install "django==1.9.*"
     Downloading/unpacking django==1.9
     Installing collected packages: django
     Successfully installed django
@@ -104,7 +104,7 @@ on Windows
 on Windows 8 and Windows 10
 > Your command line might freeze after when you try to install Django. If this happens, instead of the above command use:
 
->     C:\Users\Name\djangogirls> python -m pip install django==1.9
+>     C:\Users\Name\djangogirls> python -m pip install "django==1.9.*"
 
 on Linux
 > If you get an error when calling pip on Ubuntu 12.04 please run `python -m pip install -U --force-reinstall pip` to fix the pip installation in the virtualenv.


### PR DESCRIPTION
Install latest release of Django 1.9 (1.9.4 as of the time of this writing) instead of the first 1.9 release. The original suggested install method may lack critical security fixes added in later patches.

This syntax should work even if there weren't any point releases yet.

Tested on Linux under Bash, please test on Mac and Windows, if the quoting style is portable.
