### PR TITLE
Update README.md

### DIFF
--- a/pt/django_installation/README.md
+++ b/pt/django_installation/README.md
@@ -20,7 +20,7 @@ Para este tutorial usaremos um novo diretório`djangogirls` do seu diretório ho
     cd djangogirls
     
 
-Nós vamos fazer um virtualenv chamado `meuenv`. O formato geral desse comando é:
+Nós vamos fazer um virtualenv chamado `myvenv`. O formato geral desse comando é:
 
     python3 -m venv myvenv
     


### PR DESCRIPTION
O nome do ambiente virtual "meuenv" não é o o que está mostrado nos exemplos. Para ficar consistente, sugiro trocar para "myvenv", que me pareceu mais simples do que mudar todos os exemplos de linhas de comando para "meuenv"