### PR TITLE
Update Django package specifier

### DIFF
--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -90,10 +90,10 @@ OK, we have all important dependencies in place. We can finally install Django!
 
 ## Installing Django
 
-Now that you have your `virtualenv` started, you can install Django using `pip`. In the console, run `pip install django~=1.9.0` (note that we use a double equal sign: `==`).
+Now that you have your `virtualenv` started, you can install Django using `pip`. In the console, run `pip install django~=1.9.0` (note that we use a tilde then equal sign: `~=`).
 
     (myvenv) ~$ pip install django~=1.9.0
-    Downloading/unpacking django==1.9
+    Downloading/unpacking django~=1.9.0
     Installing collected packages: django
     Successfully installed django
     Cleaning up...

--- a/fr/deploy/README.md
+++ b/fr/deploy/README.md
@@ -178,7 +178,7 @@ Tout comme sur votre ordinateur, vous allez devoir créer un environnement virtu
     
     $ source myvenv/bin/activate
     
-    (mvenv) $  pip install django whitenoise
+    (mvenv) $ pip install django~=1.8.0 whitenoise
     Collecting django
     [...]
     Successfully installed django-1.8.2 whitenoise-2.0

--- a/fr/django_installation/instructions.md
+++ b/fr/django_installation/instructions.md
@@ -93,10 +93,10 @@ Ok, nous avons installé toutes les dépendances dont nous avions besoin. Nous a
 
 ## Installation de Django
 
-Maintenant que vous avez lancé votre `virtualenv`, vous pouvez installer Django à l'aide de `pip`. Dans votre console, tapez `pip install django==1.8`. Notez bien que nous utilisons un double signe égal : `==`).
+Maintenant que vous avez lancé votre `virtualenv`, vous pouvez installer Django à l'aide de `pip`. Dans votre console, tapez `pip install django~=1.8.0`. Notez bien que nous utilisons un tilde puis un signe égal : `~=`).
 
-    (myvenv) ~$ pip install django==1.8
-    Downloading/unpacking django==1.8
+    (myvenv) ~$ pip install django~=1.8.0
+    Downloading/unpacking django~=1.8.0
     Installing collected packages: django
     Successfully installed django
     Cleaning up...


### PR DESCRIPTION
`==1.9` will install the 1.9 version exactly, ignoring minor releases containing bugfixes and security patches. This is very bad practice.

The correct specifier is probably `Django>=1.9,<1.10` but since this is kind of complicated I went with `<1.10`. Unfortunately then the shell needs escaping.