### PR TITLE
Remove advice to move virtualenv directory

### DIFF
--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -99,7 +99,7 @@ Now that you have your `virtualenv` started, you can install Django using `pip`.
     Cleaning up...
 
 on Windows
-> If you get an error when calling pip on Windows platform please check if your project pathname contains spaces, accents or special characters (for example, `C:\Users\User Name\djangogirls`). If it does please consider moving it to another place without spaces, accents or special characters (suggestion is: `C:\djangogirls`). After the move please try the above command again.
+> If you get an error when calling pip on Windows platform please check if your project pathname contains spaces, accents or special characters (for example, `C:\Users\User Name\djangogirls`). If it does please consider using another place without spaces, accents or special characters (suggestion is: `C:\djangogirls`). Create a new virtualenv in the new directory, then delete the old one and try the above command again. (Moving the virtualenv directory won't work since virtualenv uses absolute paths.)
 
 on Windows 8 and Windows 10
 > Your command line might freeze after when you try to install Django. If this happens, instead of the above command use:


### PR DESCRIPTION
as renaming or moving a virtualenv directory will break it.
Reword warning to delete & create new virtualenv in new directory.
(Suggested order is to create new & then delete the old one, just in
case one needs to refer to the old one for any reason.)

(see "Normally environments are tied to a specific path. That means
that you cannot move an environment around or copy it to another computer."
in https://virtualenv.pypa.io/en/latest/userguide.html#making-environments-relocatable)