### PR TITLE
Add $ before commands in Virtual Environment installation

### DIFF
--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -16,12 +16,12 @@ All you need to do is find a directory in which you want to create the `virtuale
 
 For this tutorial we will be using a new directory `djangogirls` from your home directory:
 
-    mkdir djangogirls
-    cd djangogirls
+    $ mkdir djangogirls
+    $ cd djangogirls
 
 We will make a virtualenv called `myvenv`. The general command will be in the format:
 
-    python3 -m venv myvenv
+    $ python3 -m venv myvenv
 
 ### Windows
 


### PR DESCRIPTION
People don't always understand they need to type things if the `$` sign is missing. This should make it slightly clearer and consistent with the rest.