### PR TITLE
Remove outdated mention of -A

### DIFF
--- a/en/html/README.md
+++ b/en/html/README.md
@@ -156,7 +156,7 @@ Make sure you're in the `djangogirls` directory and let's tell `git` to include 
 
     $ git add --all .
 
-> __Note__ `-A` (short for "all") means that `git` will also recognize if you've deleted files (by default, it only recognizes new/modified files). Also remember (from chapter 3) that `.` means the current directory.
+> __Note__ `--all` means that `git` will also recognize if you've deleted files (by default, it only recognizes new/modified files). Also remember (from chapter 3) that `.` means the current directory.
 
 Before we upload all the files, let's check what `git` will be uploading (all the files that `git` will upload should now appear in green):
 


### PR DESCRIPTION
5c1d220a7e00a4ecf10539124bd56130fecd0983 changed -A to --all but the
note wasn't updated. This only fixes it for English, but should be done
for all languages.

See https://github.com/DjangoGirls/tutorial/pull/749 as well.