### PR TITLE
Remove confusing (myvenv) from pythonanywhere prompt

### DIFF
--- a/en/html/README.md
+++ b/en/html/README.md
@@ -179,7 +179,7 @@ Once we've done that, we upload (push) our changes up to Github:
 
 ```
 $ cd ~/my-first-blog
-(myvenv)$ git pull
+$ git pull
 [...]
 ```
 


### PR DESCRIPTION
When you navigate into the project directory at that point of the tutorial in pythonanywhere you actually see something along the lines of:

```
(myvenv) somestuffhere (master)$
```
I think it's simpler to not have the `(myvenv)` part at all (since it's not needed/relevant in that step) and only have what people need to type in.
Otherwise it can get confusing as the previous command doesn't have the same prefix.