### PR TITLE
Update install_git.md to match Windows installer

### DIFF
--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -1,7 +1,7 @@
 
 ### Windows
 
-You can download Git from [git-scm.com](http://git-scm.com/). You can hit "next next next" on all steps except for one; in the 5th step entitled "Adjusting your PATH environment", choose "Run Git and associated Unix tools from the Windows command-line" (the bottom option). Other than that, the defaults are fine. Checkout Windows-style, commit Unix-style line endings is good.
+You can download Git from [git-scm.com](http://git-scm.com/). You can hit "next next next" on all steps except for one; in the 5th step entitled "Adjusting your PATH environment", choose "Use Git and optional Unix tools from the Windows Command Prompt" (the bottom option). Other than that, the defaults are fine. Checkout Windows-style, commit Unix-style line endings is good.
 
 ### MacOS
 


### PR DESCRIPTION
Changed text to match the actual wording used in the Windows Git installer.

![2016-04-28 10_00_49-git 2 8 1 setup](https://cloud.githubusercontent.com/assets/3792171/14879723/2ef822aa-0d2b-11e6-9001-63c027416095.png)
