### PR TITLE
Added Python Execution in Windows

### DIFF
--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -468,6 +468,9 @@ Now use Python to execute the code in the file like this:
 
     $ python3 python_intro.py
     Hello, Django girls!
+Note: on windows 'python3' is not recognized as a command, instead use 'python' to execute the file:
+
+    > python python_intro.py
 
 Alright! You just ran your first Python program that was saved to a file. Feel awesome?
 
@@ -503,7 +506,7 @@ Save it and give it another run:
 
     $ python3 python_intro.py
     It works!
-
+Note: Remember for Windows 'python3' is not recognized as a command, Henceforth, Replace 'python3' with 'python' to execute the file
 ### What if a condition isn't True?
 
 In previous examples, code was executed only when the conditions were True. But Python also has `elif` and `else` statements:


### PR DESCRIPTION
Currently coaching and I realized Many people following the tutorial, and using windows OS are running into the same mistake. I was thinking putting a reminder of 'python' instead of 'python3' could make things easier