### PR TITLE
Line order instruction about Lobster font

### DIFF
--- a/en/css/README.md
+++ b/en/css/README.md
@@ -152,9 +152,9 @@ Maybe we can customize the font in our header? Paste this into your `<head>` in 
 <link href="//fonts.googleapis.com/css?family=Lobster&subset=latin,latin-ext" rel="stylesheet" type="text/css">
 ```
 
-This line will import a font called *Lobster* from Google Fonts (https://www.google.com/fonts).
+As before, check the order and place before the link to `blog/static/css/blog.css`. This line will import a font called *Lobster* from Google Fonts (https://www.google.com/fonts).
 
-Find the `h1 a` declaration block (the code between braces `{` and `}`) in the CSS file ``blog/static/css/blog.css`.  Now add the line `font-family: 'Lobster';` between the braces, and refresh the page:
+Find the `h1 a` declaration block (the code between braces `{` and `}`) in the CSS file `blog/static/css/blog.css`.  Now add the line `font-family: 'Lobster';` between the braces, and refresh the page:
 
 ```css
 h1 a {


### PR DESCRIPTION
Adding a hint as to the order of the addition of the lobster font to the CSS.

If the new line is inserted after the link to `blog/static/css/blog.css` then the font doesn't change. We (with @maxwell-k) noticed this at the second Belfast DjangoGirls event.