### PR TITLE
Correction python3 to python3.5 at prompt in Tutorial

### DIFF
--- a/en/chromebook_setup/instructions.md
+++ b/en/chromebook_setup/instructions.md
@@ -45,7 +45,7 @@ Next, run:
 ```
     mkdir djangogirls
     cd djangogirls
-    python3 -mvenv myvenv
+    python3.5 -mvenv myvenv
     source myvenv/bin/activate
     pip install django==1.9.6
 ```


### PR DESCRIPTION
Minor correction: Need at the prompt 'python3.5' instead of 'python3' when creating 'myvenv' virtual environment in the tutorial 