### PR TITLE
Provide link to skip Chromebook instructions

### DIFF
--- a/en/chromebook_setup/instructions.md
+++ b/en/chromebook_setup/instructions.md
@@ -1,4 +1,4 @@
-You can skip right over this section if you're not using a Chromebook. If you
+You can [skip right over this section](http://tutorial.djangogirls.org/en/installation/#install-python) if you're not using a Chromebook. If you
 are, your installation experience will be a little different. You can ignore the
 rest of the installation instructions.
 


### PR DESCRIPTION
This is probably the wrong way to do this, but when reading the installation instructions I wasn't sure how far to skip down the page to skip the Chromebook instructions. So I added a link that would skip down the page for you.