### PR TITLE
Change localhost to 127.0.0.1

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -154,7 +154,7 @@ Now all you need to do is check that your website is running. Open your browser 
 
 {% filename %}browser{% endfilename %}
 ```
-http://localhost:8000/
+http://127.0.0.1:8000/
 ```
 
 If you're using a Chromebook, you'll always visit your test server by accessing:


### PR DESCRIPTION
This matches both with the image below and standardizes, since the tutorial uses "127.0.0.1" later on in http://tutorial.djangogirls.org/en/django_admin/#django-admin.