### PR TITLE
redirect target fixes

### DIFF
--- a/ko/django_forms/README.md
+++ b/ko/django_forms/README.md
@@ -213,7 +213,7 @@ from django.shortcuts import redirect
 위 코드를 여러분의 파일 맨 위에 추가하세요. 그리고 새로 작성한 글을 볼 수 있도록 `post_detail` 페이지로 가라고 수정합시다.
 
     python
-    return redirect('blog.views.post_detail', pk=post.pk)
+    return redirect('post_detail', pk=post.pk)
 
 
 `blog.views.post_detail`은 우리가 이동해야 할 뷰의 이름이에요 *post_detail 뷰* 는 `pk`변수가 필요한 거 기억하고 있겠죠? `pk=post.pk`를 사용해서 뷰에게 값을 넘겨줄 거에요. 여기서 `post`는 새로 생성한 블로그 글이에요.
@@ -229,7 +229,7 @@ def post_new(request):
             post.author = request.user
             post.published_date = timezone.now()
             post.save()
-            return redirect('blog.views.post_detail', pk=post.pk)
+            return redirect('post_detail', pk=post.pk)
     else:
         form = PostForm()
     return render(request, 'blog/post_edit.html', {'form': form})
@@ -308,7 +308,7 @@ def post_edit(request, pk):
             post.author = request.user
             post.published_date = timezone.now()
             post.save()
-            return redirect('blog.views.post_detail', pk=post.pk)
+            return redirect('post_detail', pk=post.pk)
     else:
         form = PostForm(instance=post)
     return render(request, 'blog/post_edit.html', {'form': form})

--- a/ko/django_forms/README.md
+++ b/ko/django_forms/README.md
@@ -216,7 +216,7 @@ from django.shortcuts import redirect
     return redirect('post_detail', pk=post.pk)
 
 
-`blog.views.post_detail`은 우리가 이동해야 할 뷰의 이름이에요 *post_detail 뷰* 는 `pk`변수가 필요한 거 기억하고 있겠죠? `pk=post.pk`를 사용해서 뷰에게 값을 넘겨줄 거에요. 여기서 `post`는 새로 생성한 블로그 글이에요.
+`post_detail`은 우리가 이동해야 할 뷰의 이름이에요 *post_detail 뷰* 는 `pk`변수가 필요한 거 기억하고 있겠죠? `pk=post.pk`를 사용해서 뷰에게 값을 넘겨줄 거에요. 여기서 `post`는 새로 생성한 블로그 글이에요.
 
 잘 했어요. 너무 설명이 길어졌네요. 이제 *view* 의 전체 코드를 확인할게요.
 


### PR DESCRIPTION
Modified to correctly run when deployed on pythonanywhere.com
it redirected to wrong url: (yourID.pythonanywhere.com/post/new/blog.views.post_detail).
However, after this modification it redirects to correct url: (yourID.pythonanywhere.com/post/post_no)