### PR TITLE
Add sectionx and use in installation instructions

### DIFF
--- a/book.json
+++ b/book.json
@@ -12,7 +12,8 @@
         "github@2.0.0",
         "language-picker",
         "sidebar-ad",
-        "codeblock-label"
+        "codeblock-label",
+        "sectionx"
     ],
     "pluginsConfig": {
         "ga": {

--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -1,39 +1,53 @@
-### Windows
+<!--sec data-title="Windows" data-id="git_install_windows"
+data-collapse=false ces-->
 
 You can download Git from [git-scm.com](https://git-scm.com/). You can hit "next" on all steps except for one; in the fifth step entitled "Adjusting your PATH environment", choose "Use Git and optional Unix tools from the Windows Command Prompt" (the bottom option). Other than that, the defaults are fine. Checkout Windows-style, commit Unix-style line endings is good.
 
-### MacOS
+<!--endsec-->
+
+<!--sec data-title="OS X" data-id="git_install_OSX"
+data-collapse=true ces-->
 
 Download Git from [git-scm.com](https://git-scm.com/) and just follow the instructions.
 
-### Linux
+<!--endsec-->
 
-If it isn't installed already, git should be available via your package manager, so try:
-
-#### Debian or Ubuntu
+<!--sec data-title="Debian or Ubuntu" data-id="git_install_debian_ubuntu"
+data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```bash
 $ sudo apt-get install git
 ```
 
-#### Fedora (up to 21)
+<!--endsec-->
+
+<!--sec data-title="Fedora (up to 21)" data-id="git_install_fedora_21"
+data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```bash
 $ sudo yum install git
 ```
 
-#### Fedora (22+)
+<!--endsec-->
+
+<!--sec data-title="Fedora 22+" data-id="git_install_fedora_22"
+data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```bash
 $ sudo dnf install git
 ```
 
-#### openSUSE
+<!--endsec-->
+
+<!--sec data-title="openSUSE" data-id="git_install_openSUSE"
+data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```bash
 $ sudo zypper install git
 ```
+
+<!--endsec-->

--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -1,5 +1,5 @@
 <!--sec data-title="Windows" data-id="git_install_windows"
-data-collapse=false ces-->
+data-collapse=true ces-->
 
 You can download Git from [git-scm.com](https://git-scm.com/). You can hit "next" on all steps except for one; in the fifth step entitled "Adjusting your PATH environment", choose "Use Git and optional Unix tools from the Windows Command Prompt" (the bottom option). Other than that, the defaults are fine. Checkout Windows-style, commit Unix-style line endings is good.
 

--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -31,7 +31,7 @@ We will make a virtualenv called `myvenv`. The general command will be in the fo
 $ python3 -m venv myvenv
 ```
 
-### Windows
+<!--sec data-title="Windows" data-id="virtualenv_installation_windows" data-collapse=false ces-->
 
 To create a new `virtualenv`, you need to open the console (we told you about that a few chapters ago – remember?) and run `C:\Python35\python -m venv myvenv`. It will look like this:
 
@@ -42,7 +42,10 @@ C:\Users\Name\djangogirls> C:\Python35\python -m venv myvenv
 
 where `C:\Python35\python` is the directory in which you previously installed Python and `myvenv` is the name of your `virtualenv`. You can use any other name, but stick to lowercase and use no spaces, accents or special characters. It is also good idea to keep the name short – you'll be referencing it a lot!
 
-### Linux and OS X
+<!--endsec-->
+
+<!--sec data-title="Linux and OS X" data-id="virtualenv_installation_linuxosx"
+data-collapse=true ces-->
 
 Creating a `virtualenv` on both Linux and OS X is as simple as running `python3 -m venv myvenv`.
 It will look like this:
@@ -98,11 +101,14 @@ $ python3 -m venv myvenv
 >sudo apt install python3.5-venv
 >```
 
+<!--endsec-->
+
 ## Working with virtualenv
 
 The command above will create a directory called `myvenv` (or whatever name you chose) that contains our virtual environment (basically a bunch of directory and files).
 
-#### Windows
+<!--sec data-title="Windows" data-id="virtualenv_windows"
+data-collapse=false ces-->
 
 Start your virtual environment by running:
 
@@ -120,7 +126,10 @@ C:\Users\Name\djangogirls> myvenv\Scripts\activate
 >     The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at http://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy? [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"): A
 >```
 
-#### Linux and OS X
+<!--endsec-->
+
+<!--sec data-title="Linux and OS X" data-id="virtualenv_linuxosx"
+data-collapse=true ces-->
 
 Start your virtual environment by running:
 
@@ -137,6 +146,8 @@ Remember to replace `myvenv` with your chosen `virtualenv` name!
 >```
 >$ . myvenv/bin/activate
 >```
+
+<!--endsec-->
 
 You will know that you have `virtualenv` started when you see that the prompt in your console is prefixed with `(myvenv)`.
 
@@ -162,10 +173,16 @@ Successfully installed django
 Cleaning up...
 ```
 
-on Windows
+<!--sec data-title="Windows" data-id="django_err_windows"
+data-collapse=true ces-->
+
 > If you get an error when calling pip on Windows platform, please check if your project pathname contains spaces, accents or special characters (for example, `C:\Users\User Name\djangogirls`). If it does, please consider using another place without spaces, accents or special characters (suggestion: `C:\djangogirls`). Create a new virtualenv in the new directory, then delete the old one and try the above command again. (Moving the virtualenv directory won't work since virtualenv uses absolute paths.)
 
-on Windows 8 and Windows 10
+<!--endsec-->
+
+<!--sec data-title="Windows 8 and Windows 10" data-id="django_err_windows8and10"
+data-collapse=true ces-->
+
 > Your command line might freeze after when you try to install Django. If this happens, instead of the above command use:
 >
 >{% filename %}command-line{% endfilename %}
@@ -173,7 +190,13 @@ on Windows 8 and Windows 10
 >C:\Users\Name\djangogirls> python -m pip install django~=1.9.0
 >```
 
-on Linux
+<!--endsec-->
+
+<!--sec data-title="Linux" data-id="django_err_linux"
+data-collapse=true ces-->
+
 > If you get an error when calling pip on Ubuntu 12.04 please run `python -m pip install -U --force-reinstall pip` to fix the pip installation in the virtualenv.
+
+<!--endsec-->
 
 That's it! You're now (finally) ready to create a Django application!

--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -31,7 +31,8 @@ We will make a virtualenv called `myvenv`. The general command will be in the fo
 $ python3 -m venv myvenv
 ```
 
-<!--sec data-title="Windows" data-id="virtualenv_installation_windows" data-collapse=false ces-->
+<!--sec data-title="Windows" data-id="virtualenv_installation_windows"
+data-collapse=true ces-->
 
 To create a new `virtualenv`, you need to open the console (we told you about that a few chapters ago – remember?) and run `C:\Python35\python -m venv myvenv`. It will look like this:
 
@@ -108,7 +109,7 @@ $ python3 -m venv myvenv
 The command above will create a directory called `myvenv` (or whatever name you chose) that contains our virtual environment (basically a bunch of directory and files).
 
 <!--sec data-title="Windows" data-id="virtualenv_windows"
-data-collapse=false ces-->
+data-collapse=true ces-->
 
 Start your virtual environment by running:
 

--- a/en/installation/README.md
+++ b/en/installation/README.md
@@ -11,8 +11,10 @@ Good luck!
 # Installation
 In the workshop you will be building a blog, and there are a few setup tasks in the tutorial which would be good to work through beforehand so that you are ready to start coding on the day.
 
-# Chromebook setup (if you're using one)
+<!--sec data-title="Chromebook setup (if you're using one)"
+data-id="chromebook_setup" data-collapse=true ces-->
 {% include "/chromebook_setup/instructions.md" %}
+<!--endsec-->
 
 # Install Python
 {% include "/python_installation/instructions.md" %}

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -5,7 +5,7 @@
 Django is written in Python. We need Python to do anything in Django. Let's start by installing it! We want you to install Python 3.5, so if you have any earlier version, you will need to upgrade it.
 
 
-### Windows
+<!--sec data-title="Windows" data-id="python_windows" data-collapse=false ces-->
 
 You can download Python for Windows from the website https://www.python.org/downloads/release/python-351/. After downloading the ***.msi** file, you should run it (double-click on it) and follow the instructions there. It is important to remember the path (the directory) where you installed Python. It will be needed later!
 
@@ -15,7 +15,10 @@ One thing to watch out for:  on the second screen of the installation wizard, ma
 
 In upcoming steps, you'll be using the Windows Command Line (which we'll also tell you about). For now, if you need to type in some commands, go to Start menu → All Programs → Accessories → Command Prompt. (On newer versions of Windows, you might have to search for "Command Prompt" since it's sometimes hidden.)
 
-### Linux
+<!--endsec-->
+
+<!--sec data-title="Linux" data-id="python_linux"
+data-collapse=true ces-->
 
 It is very likely that you already have Python installed out of the box. To check if you have it installed (and which version it is), open a console and type the following command:
 
@@ -28,7 +31,10 @@ Python 3.5.1
 If you have a different 'micro version' of Python installed, e.g. 3.5.0, then you don't have to upgrade. If you don't have Python installed, or if you want a different version, you can install it as follows:
 
 
-#### Debian or Ubuntu
+<!--endsec-->
+
+<!--sec data-title="Debian or Ubuntu" data-id="python_debian"
+data-collapse=true ces-->
 
 Type this command into your console:
 
@@ -37,7 +43,11 @@ Type this command into your console:
 $ sudo apt-get install python3.5
 ```
 
-#### Fedora (up to 21)
+<!--endsec-->
+
+<!--sec data-title="Fedora (up to 21)" data-id="python_fedora"
+data-collapse=true ces-->
+
 
 Use this command in your console:
 
@@ -46,7 +56,10 @@ Use this command in your console:
 $ sudo yum install python3
 ```
 
-#### Fedora (22+)
+<!--endsec-->
+
+<!--sec data-title="Fedora (22+)" data-id="python_fedora22"
+data-collapse=true ces-->
 
 Use this command in your console:
 
@@ -55,7 +68,10 @@ Use this command in your console:
 $ sudo dnf install python3
 ```
 
-#### openSUSE
+<!--endsec-->
+
+<!--sec data-title="openSUSE" data-id="python_openSUSE"
+data-collapse=true ces-->
 
 Use this command in your console:
 
@@ -64,7 +80,10 @@ Use this command in your console:
 $ sudo zypper install python3
 ```
 
-### OS X
+<!--endsec-->
+
+<!--sec data-title="OSX" data-id="python_OSX"
+data-collapse=true ces-->
 
 > **Note** Before you install Python on OS X, you should ensure your Mac settings allow installing packages that aren't from the App Store. Go to System Preferences (it's in the Applications folder), click "Security & Privacy," and then the "General" tab. If your "Allow apps downloaded from:" is set to "Mac App Store," change it to "Mac App Store and identified developers."
 
@@ -72,6 +91,8 @@ You need to go to the website https://www.python.org/downloads/release/python-35
 
 * Download the *Mac OS X 64-bit/32-bit installer* file,
 * Double click *python-3.5.1-macosx10.6.pkg* to run the installer.
+
+<!--endsec-->
 
 Verify the installation was successful by opening the *Terminal* application and running the `python3` command:
 

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -82,7 +82,7 @@ $ sudo zypper install python3
 
 <!--endsec-->
 
-<!--sec data-title="OSX" data-id="python_OSX"
+<!--sec data-title="OS X" data-id="python_OSX"
 data-collapse=true ces-->
 
 > **Note** Before you install Python on OS X, you should ensure your Mac settings allow installing packages that aren't from the App Store. Go to System Preferences (it's in the Applications folder), click "Security & Privacy," and then the "General" tab. If your "Allow apps downloaded from:" is set to "Mac App Store," change it to "Mac App Store and identified developers."

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -5,7 +5,7 @@
 Django is written in Python. We need Python to do anything in Django. Let's start by installing it! We want you to install Python 3.5, so if you have any earlier version, you will need to upgrade it.
 
 
-<!--sec data-title="Windows" data-id="python_windows" data-collapse=false ces-->
+<!--sec data-title="Windows" data-id="python_windows" data-collapse=true ces-->
 
 You can download Python for Windows from the website https://www.python.org/downloads/release/python-351/. After downloading the ***.msi** file, you should run it (double-click on it) and follow the instructions there. It is important to remember the path (the directory) where you installed Python. It will be needed later!
 


### PR DESCRIPTION
Use the `sectionx` extension to put instructions for different operating systems in separate sections to address #862 .

Started with the Python installation instructions to show what it might look like.

![Example of Python installation instructions in separate sections.](https://cloud.githubusercontent.com/assets/4767109/19222432/99b65aa4-8e58-11e6-9d89-2e8537eaa745.gif)

Add `sectionx` to:
- [x] Chromebook setup.
- [x] Python installation.
- [x] Virtualenv usage.
- [x] Django installation.
- [x] Git installation.
