### PR TITLE
Use the same --all argument everywhere

### DIFF
--- a/fr/html/README.md
+++ b/fr/html/README.md
@@ -167,7 +167,7 @@ Assurez-vous que vous êtes bien dans le dossier `djangogirls`. Voici la command
     $ git add --all .
 
 
-> **Note** `-A` (abréviation de "tout") signifie que `git` va aussi analyser si vous avez supprimé des fichiers (par défaut, il ne s'intéresse qu'aux nouveaux fichiers ou à ceux modifiés). Essayez de vous rappeler du chapitre 3 : `.` permet de désigner le dossier courant.
+> **Note** `--all` (traduction de "tout") signifie que `git` va aussi analyser si vous avez supprimé des fichiers (par défaut, il ne s'intéresse qu'aux nouveaux fichiers ou à ceux modifiés). Essayez de vous rappeler du chapitre 3 : `.` permet de désigner le dossier courant.
 
 Avant que nous puissions uploader nos fichiers, regardons ce que `git` à l'intention de faire (tous les fichiers que `git` va uploader vont apparaitre en vert) :
 


### PR DESCRIPTION
We had `--all` in the code and `-A` in the Note.
Use `--all` everywhere decreases risks of confusion for the reader.

On avait `--all` dans le code et `-A` dans la note.
Utiliser `--all` partout évite une confusion pour le lecteur.