### PR TITLE
ALLOWED_HOSTS = ['*']

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -77,6 +77,15 @@ In `settings.py`, find the line that contains `TIME_ZONE` and modify it to choos
 TIME_ZONE = 'Europe/Berlin'
 ```
 
+When we deploy our website (which we'll do soon!), we need configure which URLs will potentially be used to access it.  For now, we'll tell Django to allow this website to be served from any URL.  To do this, find the line (near the beginning of the file)that contains `ALLOWED_HOSTS` and modify it to look like this:
+
+{& filename %}mysite/settings.py{% endfilename %}
+```python
+ALLOWED_HOSTS = ['*']
+```
+
+Note that putting a `'*'` in this list is potentially a security risk, but we'll leave it like that for now because we don't yet know the URL that we'll actually be using to access the website when we deploy it.  If you're curious about why this is a security risk, take a look the [https://docs.djangoproject.com/en/1.9/ref/settings/#allowed-hosts](Django documentation for this setting).
+
 We'll also need to add a path for static files. (We'll find out all about static files and CSS later in the tutorial.) Go down to the *end* of the file, and just underneath the `STATIC_URL` entry, add a new one called `STATIC_ROOT`:
 
 {% filename %}mysite/settings.py{% endfilename %}


### PR DESCRIPTION
Hi!  I'm going to be a mentor at the Chicago workshop on Saturday, December 3rd.  I think I found a stumbling block in the tutorial.

Starting in Django 1.8.16, the ALLOWED_HOSTS setting is checked even if `DEBUG` is `True`, so folks going through this tutorial will need to modify it.  I debated whether or not to set it to `['*']` in the `settings.py` section, or to go back and edit it during the deployment section.  This seemed like the easiest thing to do in the interest of getting started, but I'm glad to submit a PR for the other way if you folks think that's better.