### PR TITLE
Make pip upgrade instruction clearer

### DIFF
--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -160,8 +160,12 @@ OK, we have all important dependencies in place. We can finally install Django!
 
 Now that you have your `virtualenv` started, you can install Django.
 
-Before we do that, we should make sure we have the latest version of `pip`, the software that we use to install Django.
-In the console, run `pip install --upgrade pip`.
+Before we do that, we should make sure we have the latest version of `pip`, the software that we use to install Django:
+
+{% filename %}command-line{% endfilename %}
+```
+(myvenv) ~$ pip install --upgrade pip
+```
 
 Then run `pip install django~=1.9.0` (note that we use a tilde followed by an equal sign: `~=`) to install Django.
 


### PR DESCRIPTION
Putting it inline makes it less clear where to type it, and also makes people include the '.' when they shouldn't.