### PR TITLE
Mention some possible errors in the python intro

### DIFF
--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -793,7 +793,11 @@ Hi there!
 How are you?
 ```
 
-That was easy! Let's build our first function with parameters. We will use the previous example – a function that says 'hi' to the person running it – with a name:
+If you see an error instead, don't panic! Python is trying to help you find the source of the problem.
+If you get a **NameError**, that probably means you typed something wrong, so you should check that you used the same name when creating the function with `def hi():` and when calling it with `hi()`.
+If you get an **IndentationError**, check you don't have any extra whitespace at the start of the line: python wants all the code inside in your function to be neatly aligned.
+
+Let's build our first function with parameters. We will use the previous example – a function that says 'hi' to the person running it – with a name:
 
 {% filename %}python_intro.py{% endfilename %}
 ```python

--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -793,9 +793,10 @@ Hi there!
 How are you?
 ```
 
-If you see an error instead, don't panic! Python is trying to help you find the source of the problem.
-If you get a **NameError**, that probably means you typed something wrong, so you should check that you used the same name when creating the function with `def hi():` and when calling it with `hi()`.
-If you get an **IndentationError**, check you don't have any extra whitespace at the start of the line: python wants all the code inside in your function to be neatly aligned.
+Note: if it didn't work, don't panic! The output will help you to figure why:
+- If you get a `NameError`, that probably means you typed something wrong, so you should check that you used the same name when creating the function with `def hi():` and when calling it with `hi()`.
+- If you get an `IndentationError`, check that both of the `print` lines have the same whitespace at the start of a line: python wants all the code inside the function to be neatly aligned.
+- If there's no output at all, check that the last `hi()` *isn't* indented - if it is, that line will become part of the function too, and it will never get run.
 
 Let's build our first function with parameters. We will use the previous example – a function that says 'hi' to the person running it – with a name:
 


### PR DESCRIPTION
Hello, this is an attempt to help with https://github.com/DjangoGirls/tutorial/issues/196

Specifically, @vrutkovs's suggestion:
> People usually read the chapter line by line and get confused that
> things break (on such an early stage). The coach has to know this
> situation in beforehand and warn the student (I almost filed a bug about
> incorrect syntax in the example)

This PR just mentions some things that can go wrong when defining a function, instead of saying "that was easy".

I think adding some styling to display these kinds of things in a different way would help a lot, but I wanted to try and see if rephrasing some bits would help. Happy to extend this if it's helpful, but wanted to keep it simple to start with as I haven't read the full tutorial myself.
