### PR TITLE
Correct path to `startproject` command on Windows.

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -38,7 +38,7 @@ On Windows you should run the following command. **(Don't forget to add the peri
 
 {% filename %}command-line{% endfilename %}
 ```
-(myvenv) C:\Users\Name\djangogirls> django-admin.py startproject mysite .
+(myvenv) C:\Users\Name\djangogirls> myvenv\Scripts\django-admin.py startproject mysite .
 ```
 > The period `.` is crucial because it tells the script to install Django in your current directory (for which the period `.` is a short-hand reference).
 


### PR DESCRIPTION
The current instruction to start the project fails silently under Windows:

```
(myvenv) C:\Users\Name\djangogirls> django-admin.py startproject mysite .
```

This PR provides the path to `django-admin.py` within the virtual environment to ensure that the project can be started correctly. For some reason, the command is not being picked up otherwise, even though the virtual environment is activated.