### PR TITLE
Added clarification about directory content

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -58,7 +58,7 @@ djangogirls
         wsgi.py
         __init__.py
 ```
-
+> **Note**: in your directory structure, you will also see your `venv` directory that we created before.
 
 `manage.py` is a script that helps with management of the site. With it we will be able (amongst other things) to start a web server on our computer without installing anything else.
 


### PR DESCRIPTION
On several occasions, we had confusion about the contents of the directory after running the django-admin.py script. The directory tree suggests to show all the contents, but in fact, when following the installation guideline, venv will also sit in the djangogirls directory. This is missing in the pic, so participants sometimes think it is an error and might try to delete it. I suggest a note to fix this.