### PR TITLE
merge from djangogirls (#2)

### DIFF
--- a/en/README.md
+++ b/en/README.md
@@ -4,6 +4,10 @@
 > This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
 > To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
 
+## Welcome
+Welcome to the Django Girls Tutorial! We are happy to see you here :) In this tutorial, we will take you on a journey under the hood of web technologies, offering you a glimps on all the bits and pieces that need to come together to make the web work as we know it. 
+As all unknown things, this is going to be an adventure - but no worries, since you already worked up the courage to be here, you'll be just fine :)
+
 ## Introduction
 
 Have you ever felt that the world is more and more about technology to which you cannot (yet) relate? Have you ever wondered how to create a website but have never had enough motivation to start? Have you ever thought that the software world is too complicated for you to even try doing something on your own?

--- a/en/README.md
+++ b/en/README.md
@@ -6,7 +6,7 @@
 
 ## Introduction
 
-Have you ever felt that the world is more and more about technology and you are somehow left behind? Have you ever wondered how to create a website but have never had enough motivation to start? Have you ever thought that the software world is too complicated for you to even try doing something on your own?
+Have you ever felt that the world is more and more about technology to which you cannot (yet) relate? Have you ever wondered how to create a website but have never had enough motivation to start? Have you ever thought that the software world is too complicated for you to even try doing something on your own?
 
 Well, we have good news for you! Programming is not as hard as it seems and we want to show you how fun it can be.
 

--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -58,7 +58,7 @@ djangogirls
         wsgi.py
         __init__.py
 ```
-
+> **Note**: in your directory structure, you will also see your `venv` directory that we created before.
 
 `manage.py` is a script that helps with management of the site. With it we will be able (amongst other things) to start a web server on our computer without installing anything else.
 

--- a/es/README.md
+++ b/es/README.md
@@ -13,7 +13,7 @@ This tutorial has been translated from English into Spanish by a wonderful group
 
 Bueno, ¡tenemos buenas noticias para ti! Programar no es tan difícil como aparenta y queremos mostrarte cuán divertido puede llegar a ser.
 
-Este tutorial no te convertirá en programador mágicamente. Si quieres ser buena en esto, necesitarás meses o inclusos años de aprendizaje y práctica. Pero queremos mostrarte que programar o crear sitios web no es tan complicado como parece. Intentaremos explicar pequeñas partes lo mejor que podamos, de forma que no te sientas intimidada por la tecnología.
+Este tutorial no te convertirá en programador mágicamente. Si quieres ser buena en esto, necesitarás meses o incluso años de aprendizaje y práctica. Pero queremos mostrarte que programar o crear sitios web no es tan complicado como parece. Intentaremos explicar pequeñas partes lo mejor que podamos, de forma que no te sientas intimidada por la tecnología.
 
 ¡Esperamos poder hacerte amar la tecnología tanto como nosotras lo hacemos!
 

--- a/tr/django_orm/README.md
+++ b/tr/django_orm/README.md
@@ -120,7 +120,9 @@ Ya da belki `baslik` alanında içinde 'Nefis' kelimesini içeren tüm gönderil
 Ayrıca yayınlanmış tüm gönderilerin bir listesini alabiliriz. Bunu geçmişte `yayinlanma_tarihi` alanı belirtilmiş tüm gönderileri filtreleyerek yapıyoruz:
 
 ```
->>> from django.utils import timezone Post.objects.filter(yayinlanma_tarihi__lte=timezone.now()) []
+>>> from django.utils import timezone
+>>> Post.objects.filter(yayinlanma_tarihi__lte=timezone.now())
+>>> <QuerySet []>
 ```
 
 Maalesef, Python konsolundan eklediğimiz gönderi henüz yayınlanmadı. Bunu değiştirebiliriz! İlk olarak yayınlamak istediğimiz gönderinin bir örneğini alalım:


### PR DESCRIPTION
* inclusos for incluso

* Fixed, code seperated line from 123. Line

* A more positive feel for the "Introduction" 

The version "feel somehow left behind" has a strong negative feeling to it. To me (as a coach) this feels problematic/counterproductive when starting off the day with super motivated participants (essentially, I'm "reminding" them about the "fact" that they might be "left behind" instead of, e.g., "courageous" or "engaged"). 

I'm proposing a small correction to soften this feel. However, ideally, I would prefer the tutorial to start off with a friendly and warm welcome (and potentially congratulations that the participant worked up the courage to get herself into this in the first place). Maybe add a dedicated "Welcome" section?

* Added clarification about directory content

On several occasions, we had confusion about the contents of the directory after running the django-admin.py script. The directory tree suggests to show all the contents, but in fact, when following the installation guideline, venv will also sit in the djangogirls directory. This is missing in the pic, so participants sometimes think it is an error and might try to delete it. I suggest a note to fix this.