### PR TITLE
start server on port 8000

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -155,7 +155,7 @@ If you are on a Chromebook, use this command instead:
 
 {% filename %}Cloud 9{% endfilename %}
 ```
-(myvenv) ~/djangogirls$ python manage.py runserver 0.0.0.0:8080
+(myvenv) ~/djangogirls$ python manage.py runserver 0.0.0.0:8000
 ```
 
 If you are on Windows and this fails with `UnicodeDecodeError`, use this command instead:


### PR DESCRIPTION
Start server on port 8000, as that is the port we'll access with the browser [further below in these instructions](https://github.com/das-g/django-girls-tutorial/blame/ea7948eb5a6c62197635cb39f570a149a02c4035/en/django_start_project/README.md#L173).