### PR TITLE
fr/correct view's name 'blog.views.post_detail' to 'post_detail'

### DIFF
--- a/fr/django_forms/README.md
+++ b/fr/django_forms/README.md
@@ -211,10 +211,10 @@ from django.shortcuts import redirect
 Ajoutez-le au tout début de votre page. Maintenant, nous allons ajouter la ligne qui signifie : "aller à la page `post_detail` pour le nouveau post qui vient d'être créé".
 
 ```python
-return redirect('blog.views.post_detail', pk=post.pk)
+return redirect('post_detail', pk=post.pk)
 ```
 
-`blog.views.post_detail` est le nom de la vue où nous voulons aller. Rappelez-vous : une *vue* a besoin d'une variable `pk`. Afin de le passer à la vue, nous utilisons `pk=post.pk`, où `post` désigne le blog post nouvellement créé !
+`post_detail` est le nom de la vue où nous voulons aller. Rappelez-vous : une *vue* a besoin d'une variable `pk`. Afin de le passer à la vue, nous utilisons `pk=post.pk`, où `post` désigne le blog post nouvellement créé !
 
 Et si au lieu de parler, nous vous montrions à quoi ressemble maintenant notre *vue* ?
 
@@ -227,7 +227,7 @@ def post_new(request):
             post.author = request.user
             post.published_date = timezone.now()
             post.save()
-            return redirect('blog.views.post_detail', pk=post.pk)
+            return redirect('post_detail', pk=post.pk)
     else:
         form = PostForm()
     return render(request, 'blog/post_edit.html', {'form': form})
@@ -306,7 +306,7 @@ def post_edit(request, pk):
             post.author = request.user
             post.published_date = timezone.now()
             post.save()
-            return redirect('blog.views.post_detail', pk=post.pk)
+            return redirect('post_detail', pk=post.pk)
     else:
         form = PostForm(instance=post)
     return render(request, 'blog/post_edit.html', {'form': form})


### PR DESCRIPTION
During the latest [@DjangoGirlsBdx](https://djangogirls.org/bordeaux/) we found this issue.

### Explanation

`'blog.views.post_detail'` is not a valid view name and trigger a redirect to `http://127.0.0.1:8000/post/new/blog.views.post_detail`  which doesn't resolve.