### PR TITLE
[Korean] Add explanation about 'django==1.8'

### DIFF
--- a/ko/django_installation/instructions.md
+++ b/ko/django_installation/instructions.md
@@ -94,7 +94,7 @@
 
 ## 장고 설치하기
 
-이제 `virtualenv` 가 시작되었으니, `pip`를 이용해 장고를 설치할 수 있어요. 콘솔에서 `pip install django==1.8`를 실행해보세요. (조심하세요. 이퀄기호가 두 개예요: `==`).
+이제 `virtualenv` 가 시작되었으니, `pip`를 이용해 장고를 설치할 수 있어요. 버전이 1.8인 장고를 설치하기 위해 콘솔에서 `pip install django==1.8`를 실행해보세요. (조심하세요. 이퀄기호가 두 개예요: `==`).
 
     (myvenv) ~$ pip install django==1.8
     Downloading/unpacking django==1.8


### PR DESCRIPTION
Added explanation why we type "==1.8" for notifying users to install django of  appropriate version when they need it.