### PR TITLE
Update QuerySet representations to match Django 1.10

### DIFF
--- a/cs/django_orm/README.md
+++ b/cs/django_orm/README.md
@@ -46,7 +46,7 @@ Tohle je jednoduché: importujeme model `Post` z `blog.models`. Pojďme znovu zk
 
 ```
 >>> Post.objects.all()
-[<Post: titulek mého prvního příspěvku>, <Post: titulky dalších příspěvků>]
+<QuerySet [<Post: titulek mého prvního příspěvku>, <Post: titulky dalších příspěvků>]>
 ```  
 
 To je seznam příspěvků, které jsme dříve vytvořily pomocí Django administrátorského rozhraní. Teď nicméně chceme vytvořit příspěvky použitím Pythonu, tak jak na to?
@@ -71,7 +71,7 @@ Jaké uživatele máme v naší databázi? Zkus tohle:
 
 ```
 >>> User.objects.all()
-[<User: ola>]
+<QuerySet [<User: ola>]>
 ```  
 
 Tohle je superuser, kterého jsme vytvořily dříve! Pojďme si teď vzít instanci tohoto uživatele:
@@ -92,7 +92,7 @@ Hurá! Chceš se podívat, jestli to fungovalo?
 
 ```
 >>> Post.objects.all()
-[<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+<QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
 ```  
 
 A je to tu, další příspěvek v seznamu!

--- a/en/django_orm/README.md
+++ b/en/django_orm/README.md
@@ -54,7 +54,7 @@ This is simple: we import the model `Post` from `blog.models`. Let's try display
 {% filename %}command-line{% endfilename %}
 ```python
 >>> Post.objects.all()
-[<Post: my post title>, <Post: another post title>]
+<QuerySet [<Post: my post title>, <Post: another post title>]>
 ```
 
 This is a list of the posts we created earlier! We created these posts using the Django admin interface. But now we want to create new posts using Python, so how do we do that?
@@ -83,7 +83,7 @@ What users do we have in our database? Try this:
 {% filename %}command-line{% endfilename %}
 ```python
 >>> User.objects.all()
-[<User: ola>]
+<QuerySet [<User: ola>]>
 ```
 
 This is the superuser we created earlier! Let's get an instance of the user now:
@@ -107,7 +107,7 @@ Hurray! Wanna check if it worked?
 {% filename %}command-line{% endfilename %}
 ```python
 >>> Post.objects.all()
-[<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+<QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
 ```
 
 There it is, one more post in the list!

--- a/es/django_orm/README.md
+++ b/es/django_orm/README.md
@@ -41,7 +41,7 @@ Vamos a mostrar todos nuestros posts primero. Puedes hacerlo con el siguiente co
 Esto es simple: importamos el modelo `Post` de `blog.models`. Vamos a intentar mostrar todos los posts nuevamente:
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>]>
     
 
 Esta es una lista de las posts creadas anteriormente. Hemos creado estos posts usando la interfaz del administrador de Django. Sin embargo, ahora queremos crear nuevos posts usando Python, ¿cómo lo hacemos?
@@ -63,7 +63,7 @@ Primero importemos el modelo User:
 ¿Qué usuarios tenemos en nuestra base de datos? Veamos:
 
     >>> User.objects.all()
-    [<User: ola>]
+    <QuerySet [<User: ola>]>
     
 
 Este es el super usuario que creamos anteriormente, Vamos a obtener una instancia de ese usuario ahora:
@@ -81,7 +81,7 @@ Ahora finalmente podemos crear nuestro primer post:
 ¡Hurra! ¿Quieres probar si funcionó?
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
     
 
 ### Agrega más posts

--- a/fr/django_orm/README.md
+++ b/fr/django_orm/README.md
@@ -44,7 +44,7 @@ Rien de compliqué : nous importons le modèle `Post` depuis notre `blog.models`
 
 ```python
 >>> Post.objects.all()
-[<Post: my post title>, <Post: another post title>]
+<QuerySet [<Post: my post title>, <Post: another post title>]>
 ```
 
 Cela nous permet d'obtenir une liste des posts que nous avons créé tout à l'heure ! Rappelez-vous : nous avions créé ces posts à l'aide de l'interface d'administration de Django. Cependant, nous aimerions maintenant créer de nouveaux posts à l'aide de Python : comment allons-nous nous y prendre ?
@@ -69,7 +69,7 @@ Avons-nous des utilisateurs dans notre base de données ? Voyons voir :
 
 ```python
 >>> User.objects.all()
-[<User: ola>]
+<QuerySet [<User: ola>]>
 ```
 
 C'est le superutilisateur que nous avions créé tout à l'heure ! Essayons maintenant d'obtenir une instance de l'utilisateur :
@@ -90,7 +90,7 @@ Youpi ! Et si on vérifiait quand même si ça a marché ?
 
 ```python
 >>> Post.objects.all()
-[<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+<QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
 ```
 
 Et voilà : un post de plus dans la liste !

--- a/hu/django_orm/README.md
+++ b/hu/django_orm/README.md
@@ -41,7 +41,7 @@ Hoppá, egy hiba! Azt mondja, hogy nincs olyan, hogy Post. Igaza van -- elfelejt
 Ez egyszerű: importáljuk a `Post` modellt a `blog.models`-ből. Próbáljuk meg újra megjeleníteni a Post-okat:
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>]>
     
 
 Egy lista a posztokból, amiket korábban megírtál! Ezeket még a Django admin felületén hoztad létre. Viszont ugyanezt meg tudod tenni a Python segítségével is. De vajon hogyan?
@@ -63,7 +63,7 @@ Először importáljuk az User modellt:
 Milyen felhasználók vannak az adatbázisban? Próbáld meg ezt:
 
     >>> User.objects.all()
-    [<User: ola>]
+    <QuerySet [<User: ola>]>
     
 
 Ez a superuser, amit korábban hoztál létre! Most vegyük ennek a felhasználónak egy instance-ét:
@@ -81,7 +81,7 @@ Most pedig végre létrehozhatjuk a posztot:
 Hurrá! Meg akarod nézni, hogy működött-e?
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
     
 
 Ott is van, egy újabb poszt a listában!

--- a/it/django_orm/README.md
+++ b/it/django_orm/README.md
@@ -41,7 +41,7 @@ Ops! È comparso un errore. Ci dice che non c'è nessun Post. È corretto -- ci 
 È semplice: importiamo il modello `Post` da `blog.models`. Proviamo a rendere di nuovo visibili tutti i post:
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>]>
 
 
 È una lista di post che abbiamo creato prima! Abbiamo creato questi post usando l'interfaccia di ammisnistrazione di Django. Comunque sia, ora vogliamo creare nuovi post usando Python, quindi come lo facciamo?
@@ -63,7 +63,7 @@ Importiamo il modello User prima:
 Quali utenti abbiamo nel nostro database? Prova questo:
 
     >>> User.objects.all()
-    [<User: ola>]
+    <QuerySet [<User: ola>]>
 
 
 È il superuser che abbiamo creato prima! Ora prendiamo un'istanza del user:
@@ -81,7 +81,7 @@ Adesso possiamo finalmente creare il nostro post:
 Evviva! Vuoi controllare se funziona?
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
 
 
 Eccolo, un altro post nell'elenco!

--- a/ko/django_orm/README.md
+++ b/ko/django_orm/README.md
@@ -41,7 +41,7 @@ PythonAnywhere가 아닌 로컬 컨솔에서 아래 명령을 입력하세요. :
 간단합니다. : 우리는 `Post`모델을 `blog.models`에서 불러왔어요. 이제 모든 글들을 출력해봅시다.
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>]>
 
 
 우리가 만들었던 그 글 목록이 나타났네요! 장고 관리자 인터페이스로 만들었던 것들이에요. 그런데 파이썬으로 새 글을 포스팅하려면, 어떻게 해야할까요?
@@ -63,7 +63,7 @@ PythonAnywhere가 아닌 로컬 컨솔에서 아래 명령을 입력하세요. :
 데이터베이스에서 user는 어떤 일을 할까요? 함께 알아봅시다. :
 
     >>> User.objects.all()
-    [<User: ola>]
+    <QuerySet [<User: ola>]>
 
 
 슈퍼유저로 등록했었던 그 사용자군요! 이제 이 사용자의 인스턴스(instance)를 가져와 봅시다. :
@@ -81,7 +81,7 @@ PythonAnywhere가 아닌 로컬 컨솔에서 아래 명령을 입력하세요. :
 만세! 그런데 제대로 작동했는지 확인해봐야죠?
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
 
 
 보세요, 목록에 게시글 하나가 더 늘었네요!

--- a/pl/django_orm/README.md
+++ b/pl/django_orm/README.md
@@ -41,7 +41,7 @@ Ups! Wyskoczył błąd. Mówi on nam, że nie istnieje coś takiego jak 'Post'. 
 Nic skomplikowanego: importujemy model `Post` z `blog.models`. Spróbujmy jeszcze raz wyświetlić wszystkie wpisy:
 
     >>> Post.objects.all()
-    [<Post: Mój pierwszy wpis>, <Post: Kolejny tytuł wpisu>]
+    <QuerySet [<Post: Mój pierwszy wpis>, <Post: Kolejny tytuł wpisu>]>
     
 
 Pojawiła się lista wpisów, które dodałyśmy wcześniej! Utworzyłyśmy je przy pomocy panelu administracyjnego Django. Teraz jednak chciałybyśmy dodać nowy wpis używając Pythona. Jak to zrobimy?
@@ -63,7 +63,7 @@ Najpierw zaimportujmy model User:
 Jakich użytkowników mamy w bazie danych? Spróbuj tak:
 
     >>> User.objects.all()
-    [<User: ola>]
+    <QuerySet [<User: ola>]>
     
 
 To konto administratora, które stworzyłyśmy wcześniej! Teraz uzyskajmy dostęp do naszej instancji użytkownika:
@@ -81,7 +81,7 @@ Teraz możemy wreszcie stworzyć nasz post:
 Hura! Chciałabyś sprawdzić, czy się udało?
 
     >>> Post.objects.all()
-    [<Post: Mój pierwszy wpis>, <Post: Kolejny tytuł wpisu>, <Post: Przykładowy tytuł>]
+    <QuerySet [<Post: Mój pierwszy wpis>, <Post: Kolejny tytuł wpisu>, <Post: Przykładowy tytuł>]>
     
 
 Jest! Kolejny post na liście!
@@ -135,13 +135,13 @@ Teraz spróbujmy jeszcze raz wyświetlić listę opublikowanych wpisów (wciśni
 QuerySety umożliwiają również porządkowanie list obiektów według określonej kolejności. Spróbujmy uporządkować je według daty utworzenia, czyli zawartości pola `created_date`:
 
     >>> Post.objects.all().order_by('created_date')
-    [<Post: Mój pierwszy wpis>, <Post: Kolejny tytuł wpisu>, <Post: Przykładowy tytuł>, <Post: Wpis numer 2>, <Post: Mój trzeci post!>, <Post: Czwarty tytuł>]
+    <QuerySet [<Post: Mój pierwszy wpis>, <Post: Kolejny tytuł wpisu>, <Post: Przykładowy tytuł>, <Post: Wpis numer 2>, <Post: Mój trzeci post!>, <Post: Czwarty tytuł>]>
     
 
 Możemy także odwrócić kolejność poprzez dodanie `-` na początku:
 
     >>> Post.objects.all().order_by('-created_date')
-    [<Post: Czwarty tytuł>, <Post: Mój trzeci post!>, <Post: Wpis numer 2>, <Post: Przykładowy tytuł>, <Post: Kolejny tytuł wpisu>, <Post: Mój pierwszy wpis>]
+    <QuerySet [<Post: Czwarty tytuł>, <Post: Mój trzeci post!>, <Post: Wpis numer 2>, <Post: Przykładowy tytuł>, <Post: Kolejny tytuł wpisu>, <Post: Mój pierwszy wpis>]>
     
 
 ### Łączenie QuerySetów

--- a/pt/django_orm/README.md
+++ b/pt/django_orm/README.md
@@ -41,7 +41,7 @@ Oops! Um erro apareceu. Ele nos diz que não existe algo chamado Post. É verdad
 Isso é simples: importamos o modelo `Post` de dentro do `blog.models`. Vamos tentar mostrar todas as postagens novamente:
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>]>
     
 
 É uma lista dos posts que criamos anteriormente! Criamos esses posts usando a interface de administração do Django. No entanto, agora queremos criar novas mensagens utilizando o python, então como é que fazemos isso?
@@ -63,7 +63,7 @@ Primeiro vamos importar o modelo User:
 Quais usuários temos no nosso banco de dados? Experimente isso:
 
     >>> User.objects.all()
-    [<User: ola>]
+    <QuerySet [<User: ola>]>
     
 
 É o superusuário que criamos anteriormente! Vamos obter uma instância de usuário agora:
@@ -81,7 +81,7 @@ Agora finalmente podemos criar nossa primeira postagem:
 Viva! Quer ver se funcionou?
 
     >>> Post.objects.all()
-    [<Post: Sample title>]
+    <QuerySet [<Post: Sample title>]>
     
 
 ### Adicione mais postagens

--- a/ru/django_orm/README.md
+++ b/ru/django_orm/README.md
@@ -41,7 +41,7 @@ QuerySet, по сути, список объектов заданной Моде
 Все просто: мы импортируем модель `Post` из `blog.models`. Давай попробуем получить все записи блога еще раз:
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>]>
     
 
 Это список записей, с которыми мы работали до этого! Мы создали их через панель администратора Django. Теперь же, мы хотим создавать записи через Python, так как же мы этого добьемся?
@@ -63,7 +63,7 @@ QuerySet, по сути, список объектов заданной Моде
 Какие пользователи есть в нашей базе данных? Попробуй эту команду:
 
     >>> User.objects.all()
-    [<User: ola>]
+    <QuerySet [<User: ola>]>
     
 
 Это суперпользователь, которого мы создали ранее! Нам нужен его экземпляр:
@@ -81,7 +81,7 @@ QuerySet, по сути, список объектов заданной Моде
 Ура! Хочешь проверить, что все работает?
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
     
 
 Есть, еще один пост в списке!

--- a/sk/django_orm/README.md
+++ b/sk/django_orm/README.md
@@ -46,7 +46,7 @@ Je to jednoduché: importujeme model `Post` z `blog.models`. Skúsme teda znova 
 
 ```
 >>> Post.objects.all()
-[<Post: my post title>, <Post: another post title>]
+<QuerySet [<Post: my post title>, <Post: another post title>]>
 ```
 
 Je to zoznam príspevkov, ktoré sme už predtým vytvorili! Vytvorili sme ich pomocou Django administrátorského rozhrania. No radi by sme vytvorili nové príspevky pomocou Pythonu, tak ako na to?
@@ -71,7 +71,7 @@ Akých užívateľov máme v našej databáze? Skús toto:
 
 ```
 >>> User.objects.all()
-[<User: ola>]
+<QuerySet [<User: ola>]>
 ```
 
 To je superuser, ktorého sme už vytvorili predtým. Teraz získajme inštanciu tohto užívateľa:
@@ -92,7 +92,7 @@ Hurá! Chceš si overiť, či to fungovalo?
 
 ```
 >>> Post.objects.all()
-[<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+<QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
 ```
 
 Je to tam, jeden príspevok v zozname pribudol!

--- a/tr/django_orm/README.md
+++ b/tr/django_orm/README.md
@@ -44,7 +44,7 @@ Aman! Bir hata meydana geldi. Bize bir gönderi olmadığını söylüyor. Doğr
 
 ```
 >>> Post.objects.all()
-[<Post: Gönderi 1>, <Post: Gönderi 2>]
+<QuerySet [<Post: Gönderi 1>, <Post: Gönderi 2>]>
 ```    
 
 Daha önce yarattığımız gönderilerin listesi! Bu gönderileri Django yönetici arayüzü kullanarak yaratmıştık. Şimdi ise Python kullanarak yeni gönderiler yaratmak istiyoruz, bunu nasıl yapabiliriz?
@@ -69,7 +69,7 @@ Veritabanımızda hangi kullanıcılar var? Şu şekilde görebiliriz:
 
 ```
 >>> User.objects.all()
-[<User: zeynep>]
+<QuerySet [<User: zeynep>]>
 ```    
 
 Daha önce yarattığımız ayrıcalıklı kullanıcı! Şimdi veritabanından kullanıcı nesnesi alalım:
@@ -90,7 +90,7 @@ Yaşasın! Çalışıp çalışmadığını kontrol etmek ister misin?
 
 ```
 >>> Post.objects.all()
-[<Post: Gönderi 1>, <Post: Gönderi 2>, <Post: Harika bir gönderi>]
+<QuerySet [<Post: Gönderi 1>, <Post: Gönderi 2>, <Post: Harika bir gönderi>]>
 ```    
 
 İşte bu kadar, listede bir gönderi daha!

--- a/uk/django_orm/README.md
+++ b/uk/django_orm/README.md
@@ -40,7 +40,7 @@ A QuerySet є, по суті, списком об'єктів заданої мо
 Усе просто: імпортуємо модель `Post` з `blog.models`. Спробуємо вивести усі пости знову:
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>]>
 
 Це список з дописів, з якими ми працювали раніше! Ми створили ці дописи через панель адміністратора Django. Проте, зараз ми хочемо створити нові дописи за допомогою Python, як ми цього доб'ємось?
 
@@ -60,7 +60,7 @@ A QuerySet є, по суті, списком об'єктів заданої мо
 Які користувачі присутні в нашій базі даних? Спробуймо це:
 
     >>> User.objects.all()
-    [<User: ola>]
+    <QuerySet [<User: ola>]>
 
 Це суперкористувач, якого ми створили раніше! Нам потрібен його екземпляр:
 
@@ -75,7 +75,7 @@ A QuerySet є, по суті, списком об'єктів заданої мо
 Ура! Бажаєте перевірити, чи це працює?
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
 
 Є, ще один допис в списку!
 

--- a/zh/django_orm/README.md
+++ b/zh/django_orm/README.md
@@ -41,7 +41,7 @@
 这很简单： 我们从 `blog.models` 导入 `Post` 的模型。让我们试着再一次显示所有的帖子：
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>]>
     
 
 这是我们之前创建的文章的 list 列表！我们通过使用Django admin界面创建了这些文章。但是我们现在想通过Python来创建新的文章，那么我们应该如何做呢？
@@ -63,7 +63,7 @@
 我们在数据库中有哪些用户？试试这个：
 
     >>> User.objects.all()
-    [<User: ola>]
+    <QuerySet [<User: ola>]>
     
 
 这是一个我们之前创建的超级用户！让我们现在获取一个用户实例：
@@ -81,7 +81,7 @@
 哈哈！要检查是否有效吗？
 
     >>> Post.objects.all()
-    [<Post: my post title>, <Post: another post title>, <Post: Sample title>]
+    <QuerySet [<Post: my post title>, <Post: another post title>, <Post: Sample title>]>
     
 
 就是这样，又一个文章在列表里面！


### PR DESCRIPTION
In Django 1.10, QuerySet repr() was changed to distinguish it from an ordinary
list (https://docs.djangoproject.com/en/1.10/releases/1.10/#miscellaneous).
Update the command output in the tutorial to reflect this.