### PR TITLE
Altered ALLOWED_HOSTS to include '<your_username>.pythonanywhere.com'…

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -95,7 +95,7 @@ match our hostname on PythonAnywhere once we deploy our application so we will c
 
 {% filename %}mysite/settings.py{% endfilename %}
 ```python
-ALLOWED_HOSTS = ['127.0.0.1', '.pythonanywhere.com']
+ALLOWED_HOSTS = ['127.0.0.1', '<your_username>.pythonanywhere.com']
 ```
 
 > **Note**: If you're using a Chromebook, add this line at the bottom of your settings.py file:


### PR DESCRIPTION
Updated settings for ALLOWED_HOSTS to include '<your_username>.pythonanywhere.com' to fix the DisallowedHost error from recent Django Security updates.