### PR TITLE
Proper definition of Crowdin assets

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,19 +1,3 @@
-project_identifier: django-girls-tutorial
-api_key: 2be4b1707d0745bc96e9a5c9ffb4ca9b
-base_path: /Users/olasitarska/Desktop/Events/Django Girls/tutorial
-
 files:
-  -
-    source: "/en/**/*.md"
-    translation: "/%two_letters_code%/%original_path%/%original_file_name%"
-    ignore:
-      - /_book
-      - /node_modules
-      - /CONTRIBUTING.md
-  -
-    source: "/en/*.md"
-    translation: "/%two_letters_code%/%original_file_name%"
-    ignore:
-      - /_book
-      - /node_modules
-      - /CONTRIBUTING.md
+  - source: /en/**/*.md
+    translation: /%two_letters_code%/**/%original_file_name%


### PR DESCRIPTION
I have asked a question on slack regarding sync of tutorial between Github and Crowdin (https://djangogirls.slack.com/archives/C03PLJLM8/p1494944212777047).

This pull request resolves issue with syncing source language (`en`) from Github to Crowdin and define, where Crowding should commit translated assets. It also removes few unnecessary options.

Somebody (maybe @olasitarska  as an owner on Crowdin) should also check if API key to project on Crowdin has been regenerate as it cause potential vulnarebality (`This key gives full access to all your Crowdin project data. Treat this just like a password!` see: https://crowdin.com/project/django-girls-tutorial/settings#api)

