### PR TITLE
Remove instructions for old Fedora versions

### DIFF
--- a/cs/python_installation/instructions.md
+++ b/cs/python_installation/instructions.md
@@ -29,15 +29,7 @@ Použij tento příkaz v konzoli:
 sudo apt-get install python3.4
 ```
 
-#### Fedora (do verze 21)
-
-Použij tento příkaz v konzoli:
-
-```
-sudo yum install python3.4
-```
-
-#### Fedora (22 +)
+#### Fedora
 
 Použij tento příkaz v konzoli:
 

--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -28,17 +28,7 @@ $ sudo apt-get install git
 
 <!--endsec-->
 
-<!--sec data-title="Fedora (up to 21)" data-id="git_install_fedora_21"
-data-collapse=true ces-->
-
-{% filename %}command-line{% endfilename %}
-```bash
-$ sudo yum install git
-```
-
-<!--endsec-->
-
-<!--sec data-title="Fedora 22+" data-id="git_install_fedora_22"
+<!--sec data-title="Fedora" data-id="git_install_fedora"
 data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -77,6 +77,8 @@ Use this command in your console:
 $ sudo dnf install python3
 ```
 
+If you're on older Fedora versions you might get an error that the command dnf is not found. In that case you need to use yum instead.
+
 <!--endsec-->
 
 <!--sec data-title="openSUSE" data-id="python_openSUSE"

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -67,20 +67,7 @@ $ sudo apt-get install python3.5
 
 <!--endsec-->
 
-<!--sec data-title="Fedora (up to 21)" data-id="python_fedora"
-data-collapse=true ces-->
-
-
-Use this command in your console:
-
-{% filename %}command-line{% endfilename %}
-```
-$ sudo yum install python3
-```
-
-<!--endsec-->
-
-<!--sec data-title="Fedora (22+)" data-id="python_fedora22"
+<!--sec data-title="Fedora" data-id="python_fedora"
 data-collapse=true ces-->
 
 Use this command in your console:

--- a/es/python_installation/README.md
+++ b/es/python_installation/README.md
@@ -43,7 +43,7 @@ Tipea este comando en tu consola:
 
 Usa este comando en tu consola:
 
-    sudo yum install python3.4
+    sudo dnf install python3.4
     
 
 #### openSUSE

--- a/fr/python_installation/instructions.md
+++ b/fr/python_installation/instructions.md
@@ -27,14 +27,7 @@ Tapez cette commande dans votre terminal :
     $ sudo apt-get install python3.4
     
 
-#### Fedora (jusqu'à la version 21)
-
-Tapez cette commande dans votre terminal :
-
-    $ sudo yum install python3.4
-    
-
-#### Fedora (22+)
+#### Fedora
 
 Tapez cette commande dans votre terminal :
 

--- a/hu/python_installation/instructions.md
+++ b/hu/python_installation/instructions.md
@@ -27,14 +27,7 @@ Ha még nincs Pythonod, vagy másik verziót szeretnél telepíteni, így tehete
     $ sudo apt-get install python3.4
     
 
-#### Fedora (21-es verzióig)
-
-Írd be az alábbi programot a konzolba:
-
-    $ sudo yum install python3.4
-    
-
-#### Fedora (22+)
+#### Fedora
 
 Írd be az alábbi programot a konzolba:
 

--- a/it/python_installation/instructions.md
+++ b/it/python_installation/instructions.md
@@ -27,14 +27,7 @@ Digita questo comando nella tua console:
     $ sudo apt-get install python3.4
     
 
-#### Fedora (fino a 21)
-
-Usa questo comando nella tua console:
-
-    $ sudo yum install python3.4
-    
-
-#### Fedora (22+)
+#### Fedora
 
 Usa questo comando nella tua console:
 

--- a/ko/deploy/install_git.md
+++ b/ko/deploy/install_git.md
@@ -29,17 +29,7 @@ $ sudo apt-get install git
 
 <!--endsec-->
 
-<!--sec data-title="Fedora (up to 21)" data-id="git_install_fedora_21"
-data-collapse=true ces-->
-
-{% filename %}command-line{% endfilename %}
-```bash
-$ sudo yum install git
-```
-
-<!--endsec-->
-
-<!--sec data-title="Fedora 22+" data-id="git_install_fedora_22"
+<!--sec data-title="Fedora" data-id="git_install_fedora"
 data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}

--- a/ko/python_installation/instructions.md
+++ b/ko/python_installation/instructions.md
@@ -69,20 +69,7 @@ $ sudo apt-get install python3.5
 
 <!--endsec-->
 
-<!--sec data-title="Fedora (up to 21)" data-id="python_fedora_ko"
-data-collapse=true ces-->
-
-
-콘솔에 아래 명령어를 입력하세요. :
-
-{% filename %}command-line{% endfilename %}
-```
-$ sudo yum install python3
-```
-
-<!--endsec-->
-
-<!--sec data-title="Fedora (22+)" data-id="python_fedora22_ko"
+<!--sec data-title="Fedora" data-id="python_fedora_ko"
 data-collapse=true ces-->
 
 콘솔에 아래 명령어를 입력하세요. :

--- a/pl/python_installation/instructions.md
+++ b/pl/python_installation/instructions.md
@@ -27,14 +27,7 @@ Wpisz w konsoli poniższe polecenie:
     $ sudo apt-get install python3.4
     
 
-#### Fedora (do 21)
-
-Użyj następującego polecenia w konsoli:
-
-    $ sudo yum install python3.4
-    
-
-#### Fedora (22+)
+#### Fedora
 
 Użyj następującego polecenia w konsoli:
 

--- a/pt/python_installation/README.md
+++ b/pt/python_installation/README.md
@@ -43,7 +43,7 @@ Digite o seguinte comando no terminal:
 
 Use o seguinte comando no terminal:
 
-    sudo yum install python3.4
+    sudo dnf install python3.4
     
 
 #### openSUSE

--- a/ru/python_installation/instructions.md
+++ b/ru/python_installation/instructions.md
@@ -27,14 +27,7 @@ Django написан на Python. Нам нужен Python, чтобы сдел
     $ sudo apt-get install python3.4
     
 
-#### Fedora (версии вплоть до 21)
-
-Используй следующую команду в консоли:
-
-    $ sudo yum install python3.4
-    
-
-#### Fedora (версии 22 и выше)
+#### Fedora
 
 Используй следующую команду в консоли:
 

--- a/sk/python_installation/instructions.md
+++ b/sk/python_installation/instructions.md
@@ -29,15 +29,7 @@ Zadaj do konzoly tento príkaz:
 $ sudo apt-get install python3.4
 ```
 
-#### Fedora (do verzie 21)
-
-Použi v konzole tento príkaz:
-
-```
-$ sudo yum install python3.4
-```
-
-#### Fedora (od verzie 22)
+#### Fedora
 
 Použi v konzole tento príkaz:
 

--- a/tr/python_installation/instructions.md
+++ b/tr/python_installation/instructions.md
@@ -29,15 +29,7 @@ Terminale bu komutu girin:
 $ sudo apt-get install python3.4
 ```    
 
-#### Fedora (21'e kadar)
-
-Terminalde kullanmanız gereken komut:
-
-```
-$ sudo yum install python3.4
-```    
-
-#### Fedora (22+)
+#### Fedora
 
 Terminalde kullanmanız gereken komut:
 

--- a/uk/deploy/install_git.md
+++ b/uk/deploy/install_git.md
@@ -18,12 +18,7 @@ Git можна завантажити з [git-scm.com](https://git-scm.com/). В
     $ sudo apt-get install git
 
 
-#### Fedora (до 21)
-
-    $ sudo yum install git
-
-
-#### Fedora (22+)
+#### Fedora
 
     $ sudo dnf install git
 

--- a/uk/python_installation/instructions.md
+++ b/uk/python_installation/instructions.md
@@ -29,14 +29,7 @@ Python для Windows можна завантажити з сайту https://ww
     $ sudo apt-get install python3.4
 
 
-#### Fedora (до версії 21)
-
-Скористайтеся наступною командою в консолі:
-
-    $ sudo yum install python3.4
-
-
-#### Fedora (22+)
+#### Fedora
 
 Скористайтеся наступною командою в консолі:
 

--- a/zh/python_installation/instructions.md
+++ b/zh/python_installation/instructions.md
@@ -27,14 +27,7 @@ Django 是用 Python 写的。 在 Django 中，我们需要使用 Python 语言
     $ sudo apt-get install python3.4
     
 
-#### Fedora (up to 21)
-
-在您的控制台中使用此命令：
-
-    $ sudo yum install python3.4
-    
-
-#### Fedora (22+)
+#### Fedora
 
 在您的控制台中使用此命令：
 


### PR DESCRIPTION
According to https://fedoraproject.org/wiki/End_of_life Fedora 21 has been EOL since 2015-12-01. We can expect that users have upgraded by now or know to use yum instead of dnf.

Some languages still have instructions for older python versions and they're not likely to work anymore but I decided to leave that in for now since I don't speak those languages.