### PR TITLE
Fixed Django version on PythonAnywhere and reviewed some typos

### DIFF
--- a/pt/deploy/README.md
+++ b/pt/deploy/README.md
@@ -59,6 +59,7 @@ Git irá controlar as alterações para todos os arquivos e pastas neste diretó
     __pycache__
     myvenv
     db.sqlite3
+    static/
     .DS_Store
 
 
@@ -193,13 +194,11 @@ Assim como fez em seu próprio computador, você pode criar um virtualenv na Pyt
 
     20:20 ~ $ source myvenv/bin/activate
 
-    (mvenv)20:20 ~ $  pip install django whitenoise
+    (mvenv)20:20 ~ $  pip install -r requirements.txt
     Collecting django
     [...]
     Successfully installed django-1.8.5 whitenoise-2.0
 
-
-<!--TODO: think about using requirements.txt instead of pip install.-->
 
 ### Coleta de arquivos estáticos.
 

--- a/pt/django_forms/README.md
+++ b/pt/django_forms/README.md
@@ -25,7 +25,7 @@ class PostForm(forms.ModelForm):
 
     class Meta:
         model = Post
-        fields = ('title', 'text',)
+        fields = ('title', 'text')
 ```
 
 

--- a/pt/django_installation/README.md
+++ b/pt/django_installation/README.md
@@ -93,13 +93,15 @@ Ok, nós temos todas as dependências importantes no lugar. Finalmente podemos i
 
 ## Instalando o Django
 
-Agora que você tem a sua `virtualenv` iniciado, você pode instalar Django usando `pip`. No console, execute `pip install django==1.8.5` (Perceba que usamos um duplo sinal de igual: `==`).
+Agora que você tem o seu `virtualenv` iniciado, você pode instalar Django e o Whitenoise usando `pip` e guardaremos as versões deles num arquivo requirements.txt para uso posterior durante a implantação, mais adiante falaremos mais sobre o Whitenoise. No console, execute `pip install django==1.8.5 whitenoise==2.0` \(Perceba que usamos um duplo sinal de igual: `==`\). Após isso, execute `pip freeze > requirements.txt` para congelar as versões deles e garantir que no futuro conseguiremos rodar nosso projeto com as versões certas das coisas \(Perceba que usamos um sinal de maior: `>`\).
 
-    (myvenv) ~$ pip install django==1.8.5
-    Downloading/unpacking django==1.8.5
-    Installing collected packages: django
-    Successfully installed django
+    (myvenv) ~$ pip install django==1.8.5 whitenoise==2.0
+    Downloading/unpacking django==1.8.5 whitenoise==2.0
+    Collecting 
+    Installing collected packages: django, whitenoise
     Cleaning up...
+
+    (myvenv) ~$ pip freeze > requirements.txt
     
 
 no Windows


### PR DESCRIPTION
On the PythonAnywhere step on "pt" version, there's a `pip install` install step that doesn't mention the same version recommended on the django install step. 
So at the django install step I've added a `pip freeze` and on deploying I've fixed this issue with a `pip install -r requirements.txt`.

Also, I have fixed a small typo on the forms step.