### PR TITLE
Add sudo apt update command

### DIFF
--- a/en/chromebook_setup/instructions.md
+++ b/en/chromebook_setup/instructions.md
@@ -41,6 +41,7 @@ In your terminal at the bottom of the Cloud 9 interface, run the following:
 
 {% filename %}Cloud 9{% endfilename %}
 ```
+sudo apt update
 sudo apt install python3.5-venv
 ```
 


### PR DESCRIPTION
On the latest Cloud 9 VM, an update is required before python3.5-venv will install.

This is a replacement/improvement for the earlier pull request: https://github.com/DjangoGirls/tutorial/pull/1051