### PR TITLE
[Czech] Fix typo in command

### DIFF
--- a/cs/django_start_project/README.md
+++ b/cs/django_start_project/README.md
@@ -114,7 +114,7 @@ Running migrations:
 
 A máme hotovo! Čas spustit webový server a měla bys vidět naše fungující webové stránky!
 
-Pro spuštění musíš být v adresáři, který obsahuje soubor `manage.py` (adresář `djangogirls`). V konzoli spustíš webový server zadáním `pythonu manage.py runserver`:
+Pro spuštění musíš být v adresáři, který obsahuje soubor `manage.py` (adresář `djangogirls`). V konzoli spustíš webový server zadáním `python manage.py runserver`:
 
 ```
 (myvenv) ~/djangogirls$ python manage.py runserver


### PR DESCRIPTION
We found that there is misspelled `python` in one command.