### PR TITLE
[Turkish] PostForm() type correction

### DIFF
--- a/tr/django_forms/README.md
+++ b/tr/django_forms/README.md
@@ -121,7 +121,7 @@ def post_new(request):
     return render(request, 'blog/post_edit.html', {'form': form})
 ```    
 
-Yeni bir `Post` formu oluşturmak için `PostForm()` fonksiyonunu çağırmak ve template'e iletmek gerekir. Bu *view*'a geri döneceğiz, fakat öncesinde form için hızlıca bir şablon oluşturalım.
+Yeni bir `Post` formu oluşturmak için `PostForm()`u çağırmak ve template'e iletmek gerekir. Bu *view*'a geri döneceğiz, fakat öncesinde form için hızlıca bir şablon oluşturalım.
 
 ## Template
 


### PR DESCRIPTION
PostForm() is a class and we don't need to say anything about PostForm() type.