### PR TITLE
Add www to front of gettingstartedwithdjango url

### DIFF
--- a/cs/whats_next/README.md
+++ b/cs/whats_next/README.md
@@ -36,5 +36,5 @@ Později můžeš zkusit, některý ze zdrojů uvedených níže. Všechny můž
  [7]: https://www.codecademy.com/tracks/web
  [8]: https://github.com/ggcarrots/django-carrots/
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://gettingstartedwithdjango.com/
+ [10]: http://www.gettingstartedwithdjango.com/
  [11]: https://twoscoopspress.com/products/two-scoops-of-django-1-8

--- a/en/whats_next/README.md
+++ b/en/whats_next/README.md
@@ -19,6 +19,6 @@ Later on, you can try the resources listed below. They're all very recommended!
 - [Code Academy HTML & CSS course](https://www.codecademy.com/tracks/web)
 - [Django Carrots tutorial](https://github.com/ggcarrots/django-carrots)
 - [Learn Python The Hard Way book](http://learnpythonthehardway.org/book/)
-- [Getting Started With Django video lessons](http://gettingstartedwithdjango.com/)
+- [Getting Started With Django video lessons](http://www.gettingstartedwithdjango.com/)
 - [Two Scoops of Django: Best Practices for Django 1.8 book](https://twoscoopspress.com/products/two-scoops-of-django-1-8)
 - [Hello Web App: Learn How to Build a Web App](https://hellowebapp.com/)

--- a/es/whats_next/README.md
+++ b/es/whats_next/README.md
@@ -36,5 +36,5 @@ Más adelante, puedes intentar los recursos listados a continuación. ¡Son todo
  [7]: https://www.codecademy.com/tracks/web
  [8]: https://github.com/ggcarrots/django-carrots/
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://gettingstartedwithdjango.com/
+ [10]: http://www.gettingstartedwithdjango.com/
  [11]: https://twoscoopspress.org/products/two-scoops-of-django-1-6

--- a/fr/whats_next/README.md
+++ b/fr/whats_next/README.md
@@ -35,5 +35,5 @@ Ensuite, vous pouvez essayer les ressources listées ci-dessous. Elles sont tout
  [7]: https://www.codecademy.com/tracks/web
  [8]: https://github.com/ggcarrots/django-carrots/
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://gettingstartedwithdjango.com/
+ [10]: http://www.gettingstartedwithdjango.com/
  [11]: https://twoscoopspress.com/products/two-scoops-of-django-1-8

--- a/hu/whats_next/README.md
+++ b/hu/whats_next/README.md
@@ -36,5 +36,5 @@ Később megpróbálkozhatsz a lenti listában lévő anyagokkal is. Ezeket mind
  [7]: https://www.codecademy.com/tracks/web
  [8]: https://github.com/ggcarrots/django-carrots/
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://gettingstartedwithdjango.com/
+ [10]: http://www.gettingstartedwithdjango.com/
  [11]: https://twoscoopspress.com/products/two-scoops-of-django-1-8

--- a/it/whats_next/README.md
+++ b/it/whats_next/README.md
@@ -35,5 +35,5 @@ Più avanti potrai provare le risorse elencate qui sotto. Sono tutte molto consi
  [7]: https://www.codecademy.com/tracks/web
  [8]: https://github.com/ggcarrots/django-carrots
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://gettingstartedwithdjango.com/
+ [10]: http://www.gettingstartedwithdjango.com/
  [11]: https://twoscoopspress.com/products/two-scoops-of-django-1-8

--- a/ko/whats_next/README.md
+++ b/ko/whats_next/README.md
@@ -21,6 +21,6 @@
 - [Code Academy HTML & CSS course](https://www.codecademy.com/tracks/web)
 - [Django Carrots tutorial](https://github.com/ggcarrots/django-carrots)
 - [Learn Python The Hard Way book](http://learnpythonthehardway.org/book/)
-- [Getting Started With Django video lessons](http://gettingstartedwithdjango.com/)
+- [Getting Started With Django video lessons](http://www.gettingstartedwithdjango.com/)
 - [Two Scoops of Django: Best Practices for Django 1.8 book](https://twoscoopspress.com/products/two-scoops-of-django-1-8)
 - [Hello Web App: Learn How to Build a Web App](https://hellowebapp.com/)

--- a/pl/whats_next/README.md
+++ b/pl/whats_next/README.md
@@ -36,5 +36,5 @@ Możesz też wypróbować materiały, które wypisałyśmy poniżej. Wszystkie b
  [7]: https://www.codecademy.com/tracks/web/
  [8]: https://github.com/ggcarrots/django-carrots/
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://www.gettingstartedwithdjango.com/
+ [10]: http://www.www.gettingstartedwithdjango.com/
  [11]: https://twoscoopspress.com/products/two-scoops-of-django-1-8/

--- a/pt/whats_next/README.md
+++ b/pt/whats_next/README.md
@@ -35,5 +35,5 @@ Depois você pode tentar as fontes listadas abaixo. Todas elas são recomendadas
  [7]: https://www.codecademy.com/tracks/web
  [8]: https://github.com/ggcarrots/django-carrots/
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://gettingstartedwithdjango.com/
+ [10]: http://www.gettingstartedwithdjango.com/
  [11]: https://twoscoopspress.org/products/two-scoops-of-django-1-6

--- a/ru/whats_next/README.md
+++ b/ru/whats_next/README.md
@@ -36,5 +36,5 @@
  [7]: https://www.codecademy.com/tracks/web
  [8]: https://github.com/ggcarrots/django-carrots/
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://gettingstartedwithdjango.com/
+ [10]: http://www.gettingstartedwithdjango.com/
  [11]: https://twoscoopspress.com/products/two-scoops-of-django-1-8

--- a/sk/whats_next/README.md
+++ b/sk/whats_next/README.md
@@ -36,5 +36,5 @@ Neskôr môžeš skúsiť zdroje uvedené nižšie. Všetky veľmi odporúčame!
  [7]: https://www.codecademy.com/tracks/web
  [8]: http://django.carrots.pl/en/
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://gettingstartedwithdjango.com/
+ [10]: http://www.gettingstartedwithdjango.com/
  [11]: https://twoscoopspress.com/products/two-scoops-of-django-1-8

--- a/tr/whats_next/README.md
+++ b/tr/whats_next/README.md
@@ -36,5 +36,5 @@ Sonra ise aşağıda listelenen diğer kaynakları deneyebilirsin. Hepsini öner
  [7]: http://www.codecademy.com/tracks/web
  [8]: http://django.carrots.pl/en/
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://gettingstartedwithdjango.com/
+ [10]: http://www.gettingstartedwithdjango.com/
  [11]: http://twoscoopspress.com/products/two-scoops-of-django-1-8

--- a/uk/whats_next/README.md
+++ b/uk/whats_next/README.md
@@ -21,6 +21,6 @@
 - [Code Academy HTML & CSS course](https://www.codecademy.com/tracks/web)
 - [Django Carrots tutorial](https://github.com/ggcarrots/django-carrots)
 - [Learn Python The Hard Way book](http://learnpythonthehardway.org/book/)
-- [Getting Started With Django video lessons](http://gettingstartedwithdjango.com/)
+- [Getting Started With Django video lessons](http://www.gettingstartedwithdjango.com/)
 - [Two Scoops of Django: Best Practices for Django 1.8 book](https://twoscoopspress.com/products/two-scoops-of-django-1-8)
 - [Hello Web App: Learn How to Build a Web App](https://hellowebapp.com/)

--- a/zh/whats_next/README.md
+++ b/zh/whats_next/README.md
@@ -35,6 +35,6 @@
  [7]: https://www.codecademy.com/tracks/web
  [8]: https://github.com/ggcarrots/django-carrots/
  [9]: http://learnpythonthehardway.org/book/
- [10]: http://gettingstartedwithdjango.com/
+ [10]: http://www.gettingstartedwithdjango.com/
  [11]: https://twoscoopspress.com/products/two-scoops-of-django-1-8
 


### PR DESCRIPTION
This link was broken without the www, this fixed the issue.