### PR TITLE
Fix: links to Chromebook Setup

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -2,6 +2,7 @@
 
 * [Introduction](README.md)
 * [Installation](installation/README.md)
+* [Installation (chromebook)](chromebook_setup/README.md)
 * [How the Internet works](how_the_internet_works/README.md)
 * [Introduction to command line](intro_to_command_line/README.md)
 * [Python installation](python_installation/README.md)

--- a/ko/SUMMARY.md
+++ b/ko/SUMMARY.md
@@ -2,6 +2,7 @@
 
 *   [들어가며](README.md)
 *   [설치하기](installation/README.md)
+*   [설치하기 (chromebook)](chromebook_setup/README.md)
 *   [인터넷은 어떻게 작동할까요](how_the_internet_works/README.md)
 *   [Command Line 시작하기](intro_to_command_line/README.md)
 *   [Python 설치하기](python_installation/README.md)


### PR DESCRIPTION
As noted in Issues #1071 and #1072 , the markdown links to the Chromebook Setup page fail to load that page.

While the embedded instance works fine (visible within the tutorial's [Installation](https://tutorial.djangogirls.org/en/installation/#chromebook-setup-if-youre-using-one)), it may be that in order for the standalone page to be accessible, it needs to be accounted for in the table of contents. That's my understanding from https://github.com/GitbookIO/feedback/issues/467. 

This PR adds the chromebook setup to the table of contents for the EN and KO versions (the only ones with chromebook content). 