### PR TITLE
Pl win fixes

### DIFF
--- a/pl/deploy/README.md
+++ b/pl/deploy/README.md
@@ -197,7 +197,7 @@ Na tę chwilę musimy tylko uruchomić polecenie `collectstatic` na serwerze. Po
 
     (myvenv) $ python manage.py collectstatic
 
-Będziemy z powżyszego polecenia korzystać za każdym razem gdy dodamy nowe pliki statyczne. Przy kolejnych uruchomieniach tego polecenia, najprawdopodobniej zobaczysz poniższe ostrzeżenie:
+Będziemy z powyższego polecenia korzystać za każdym razem gdy dodamy nowe pliki statyczne. Przy kolejnych uruchomieniach tego polecenia, najprawdopodobniej zobaczysz poniższe ostrzeżenie:
 
     You have requested to collect static files at the destination
     location as specified in your settings:

--- a/pl/deploy/README.md
+++ b/pl/deploy/README.md
@@ -197,6 +197,8 @@ Na tę chwilę musimy tylko uruchomić polecenie `collectstatic` na serwerze. Po
 
     (myvenv) $ python manage.py collectstatic
 
+Będziemy z powżyszego polecenia korzystać za każdym razem gdy dodamy nowe pliki statyczne. Przy kolejnych uruchomieniach tego polecenia, najprawdopodobniej zobaczysz poniższe ostrzeżenie:
+
     You have requested to collect static files at the destination
     location as specified in your settings:
 

--- a/pl/deploy/README.md
+++ b/pl/deploy/README.md
@@ -52,7 +52,8 @@ Zapisz go jako `.gitignore` w folderze najwyższego poziomu "djangogirls".
 
 > **Uwaga** Ta kropka na początku nazwy pliku jest ważna! Jeśli masz jakieś problemy z utworzeniem tego pliku (na przykład, jeśli pracujesz na Macu to Finder broni się przed zapisywaniem plików, które zaczynają się od kropki) to użyj "Zapisz jako" w swoim edytorze, działa bezbłędnie.
 
-Dobrym nawykiem jest wpisywanie polecenia `git status` zanim wpiszesz `git add` albo gdy nie jesteś pewna co się zmieniło. To powinno cię ustrzec przed nieprzyjemnymi niespodziankami, takimi jak dodanie lub zmienienie nieprawidłowych plików. Polecenie `git status` zwraca między innymi informacje o plikach, które zostały dodane/zmienione/usunięte. Po wpisaniu polecenia powinnaś zobaczyć coś podobnego do tego:
+Dobrym nawykiem jest wpisywanie polecenia `
+` zanim wpiszesz `git add` albo gdy nie jesteś pewna co się zmieniło. To powinno cię ustrzec przed nieprzyjemnymi niespodziankami, takimi jak dodanie lub zmienienie nieprawidłowych plików. Polecenie `git status` zwraca między innymi informacje o plikach, które zostały dodane/zmienione/usunięte. Po wpisaniu polecenia powinnaś zobaczyć coś podobnego do tego:
 
     $ git status
     On branch master
@@ -290,13 +291,52 @@ Mamy wszystko gotowe! Naciśnij duży zielony przycisk **Reload** ("Odśwież"),
 
 ## Porady dotyczące debugowania
 
-Jeśli odwiedzając swoją stronę zobaczysz błąd, to pierwszym miejscem, w którym powinnaś poszukać informacji o tym, co się stało jest twój **dziennik błędów** (ang. "error log"). Znajdziesz do niego link na karcie [Web][8] w PythonAnywhere. Sprawdź czy znajdują się tam jakieś komunikaty o błędach; te najświeższe znajdują się na samym dole strony. Typowe problemy to:
+Całkiem prawdopodobne, że zamiast swojej strony zobaczysz błąd.
+Pierwszym miejscem, w którym powinnaś poszukać informacji o tym, co się stało jest twój **dziennik błędów** (ang. "error log"). Znajdziesz do niego link na karcie [Web][8] w PythonAnywhere. Sprawdź czy znajdują się tam jakieś komunikaty o błędach; te najświeższe znajdują się na samym dole strony. 
+
+Najprawdopodobniej zobaczysz tam informację, że adres pod którym znajduje się Twoja strona nie został rozpoznany przez Twoją aplikację:
+
+    Invalid HTTP_HOST header: '<your-username>.pythonanywhere.com'. You may need to add '<your-username>.pythonanywhere.com' to ALLOWED_HOSTS.
+
+Ze względów bezpieczństwa, Twoja aplikacja odpowiada tylko na żądania adresowane do niej (tak jak Ty nie czytasz wiadomości nieadresowanych do Ciebie, z obawy, że to oszustwo).
+Musisz pomóc jej zrozumieć, jak nazywa się jej nowy dom. Na swoim komputerze otwórz plik `settings.py` znajdujący się w katalogu `mysite`. Zobaczysz w nim powód całego zamieszania - pustą tablicę:
+
+    ALLOWED_HOSTS = []
+ 
+Teraz, kiedy masz już konto na PythonAnywhere i znasz swój adres, możesz go tu wpisać:
+
+    ALLOWED_HOSTS = ['<twoja-nazwa-użytkownika>.pythonanywhere.com']
+
+Zwróć uwagę, żeby podać swoją nazwę użytkownika na PythonAnywhere w miejsce `<twoja-nazwa-użytkownika>` oraz, żeby nie wpisać "https://" ani "/" :)
+Gdy zapiszesz zmiany w `settings.py` na swoim komputerze, trzeba wykonać jeszcze ponowne wdrożenie, aby znalazły się one na serwerze, co wymaga poniższych kroków.
+
+Najpierw upewnij się, że zmieniłaś tylko plik `settings.py`:
+
+    $ git status
+
+Następnie zapisz te zmiany w repozytorium:
+
+    $ git add --all
+    $ git commit -m 'Added my server to ALLOWED_HOSTS'
+
+Po czym "wypchnij" zmiany do GitHuba:
+
+    $ git push
+    
+Teraz przejdź do konsoli Bash w PythonAnywhere i "ściągnij" te zmiany z GitHuba:
+
+    $ cd ~/my-first-blog
+    $ git pull
+   
+Na koniec na zakładce [Web][8] kliknij w "Reload".
+
+Inne typowe problemy to:
 
  [8]: https://www.pythonanywhere.com/web_app_setup/
 
 *   Pominięcie jednego z kroków, które powinnyśmy zrobić w konsoli: stworzenie środowiska wirtualnego, aktywowanie go, instalacja Django, pobranie plików statycznych, migracja bazy danych.
 
-*   Pomyłka w ścieżce do środowiska wirtualnego w zakładce "Web" -- jeśli coś jest nie tak, wyświetli Ci się tam mały czerwony komunikat błędu.
+*   Pomyłka w ścieżce do środowiska wirtualnego w zakładce [Web][8] -- jeśli coś jest nie tak, wyświetli Ci się tam mały czerwony komunikat błędu.
 
 *   Zrobienie błędu w pliku konfiguracyjnym WSGI -- czy dobrze zapisałaś ścieżkę do katalogu my-first-blog?
 

--- a/pl/deploy/README.md
+++ b/pl/deploy/README.md
@@ -166,7 +166,7 @@ To polecenie ściągnie kopię twojego kodu na PythonAnywhere. By to sprawdzić,
 
 ### Tworzenie środowiska wirtualnego na PythonAnywhere
 
-Tak samo jak to robiłaś na swoim komputerze, możesz stworzyć środowisko wirtualne na PythonAnywhere. W konsoli Bash wpisz:
+Tak samo jak to robiłaś na swoim komputerze, możesz stworzyć środowisko wirtualne na PythonAnywhere. Polecania poniżej nieco się [różnią](https://www.reddit.com/r/learnpython/comments/4hsudz/pyvenv_vs_virtualenv/), od tych, które wykonałaś na swoim komputerze, ponieważ serwer na którym je wykonasz ma zainstalowane inne oprogramowanie. W konsoli Bash wpisz:
 
     $ cd my-first-blog
 

--- a/pl/deploy/README.md
+++ b/pl/deploy/README.md
@@ -297,7 +297,7 @@ Najprawdopodobniej zobaczysz tam informację, że adres pod którym znajduje si�
 
     Invalid HTTP_HOST header: '<your-username>.pythonanywhere.com'. You may need to add '<your-username>.pythonanywhere.com' to ALLOWED_HOSTS.
 
-Ze względów bezpieczństwa, Twoja aplikacja odpowiada tylko na żądania adresowane do niej (tak jak Ty nie czytasz wiadomości nieadresowanych do Ciebie, z obawy, że to oszustwo).
+Ze względów bezpieczeństwa, Twoja aplikacja odpowiada tylko na żądania adresowane do niej (tak jak Ty nie czytasz wiadomości nieadresowanych do Ciebie, z obawy, że to oszustwo).
 Musisz pomóc jej zrozumieć, jak nazywa się jej nowy dom. Na swoim komputerze otwórz plik `settings.py` znajdujący się w katalogu `mysite`. Zobaczysz w nim powód całego zamieszania - pustą tablicę:
 
     ALLOWED_HOSTS = []
@@ -327,7 +327,7 @@ Teraz przejdź do konsoli Bash w PythonAnywhere i "ściągnij" te zmiany z GitHu
     $ cd ~/my-first-blog
     $ git pull
    
-Na koniec na zakładce [Web][8] kliknij w "Reload".
+Na koniec w zakładce [Web][8] kliknij w "Reload".
 
 Inne typowe problemy to:
 

--- a/pl/deploy/README.md
+++ b/pl/deploy/README.md
@@ -52,8 +52,7 @@ Zapisz go jako `.gitignore` w folderze najwyższego poziomu "djangogirls".
 
 > **Uwaga** Ta kropka na początku nazwy pliku jest ważna! Jeśli masz jakieś problemy z utworzeniem tego pliku (na przykład, jeśli pracujesz na Macu to Finder broni się przed zapisywaniem plików, które zaczynają się od kropki) to użyj "Zapisz jako" w swoim edytorze, działa bezbłędnie.
 
-Dobrym nawykiem jest wpisywanie polecenia `
-` zanim wpiszesz `git add` albo gdy nie jesteś pewna co się zmieniło. To powinno cię ustrzec przed nieprzyjemnymi niespodziankami, takimi jak dodanie lub zmienienie nieprawidłowych plików. Polecenie `git status` zwraca między innymi informacje o plikach, które zostały dodane/zmienione/usunięte. Po wpisaniu polecenia powinnaś zobaczyć coś podobnego do tego:
+Dobrym nawykiem jest wpisywanie polecenia `git status` zanim wpiszesz `git add` albo gdy nie jesteś pewna co się zmieniło. To powinno cię ustrzec przed nieprzyjemnymi niespodziankami, takimi jak dodanie lub zmienienie nieprawidłowych plików. Polecenie `git status` zwraca między innymi informacje o plikach, które zostały dodane/zmienione/usunięte. Po wpisaniu polecenia powinnaś zobaczyć coś podobnego do tego:
 
     $ git status
     On branch master

--- a/pl/django_templates/README.md
+++ b/pl/django_templates/README.md
@@ -26,7 +26,7 @@ Spróbuj tak zrobić w szablonie` blog/templates/blog/post_list.html`. Zastąp w
 
 Jak widzisz, dostaliśmy tylko tyle:
 
-    <QuerySet [<Post: My second post>, <Post: My first post>]>
+    [<Post: My second post>, <Post: My first post>]
 
 
 Oznacza to tyle, że Django rozumie to jako listę obiektów. Pamiętasz z rozdziału **Wprowadzenie do Pythona**, jak możemy wyświetlić zawartość listy? Tak, za pomocą pętli for! W szablonie Django używamy ich w ten sposób:

--- a/pl/django_views/README.md
+++ b/pl/django_views/README.md
@@ -2,7 +2,7 @@
 
 Czas uporać się z błędem, który pozostawiłyśmy po poprzednim rozdziale. :)
 
-*Widok* jest miejscem, w którym umieszczamy "logikę" naszej aplikacji. Pobierze on informacje od modelu, który wcześniej utworzyłaś, a następnie przekaże je do szablonu (`template`). Nauczymy się tworzyć szablony w następnym rozdziale. Widoki to po prostu metody w Django, tylko nieco bardziej skomplikowane niż te, którymi zajmowałyśmy się w rozdziale **Wprowadzenie do Pythona**.
+*Widok* jest miejscem, w którym umieszczamy "logikę" naszej aplikacji. Pobierze on informacje od modelu, który wcześniej utworzyłaś, a następnie przekaże je do szablonu (`template`). Nauczymy się tworzyć szablony w następnym rozdziale. W Django widoki to po prostu funkcje, tylko nieco bardziej skomplikowane niż te, którymi zajmowałyśmy się w rozdziale **Wprowadzenie do Pythona**.
 
 Widoki (ang. views) są przechowywane w pliku `views.py`. Dodajmy *views* do naszego pliku `blog/views.py`.
 
@@ -23,7 +23,7 @@ def post_list(request):
     return render(request, 'blog/post_list.html', {})
 ```
 
-Jak widzisz, stworzyłyśmy metodę (`def`) zwaną `post_list`, która przyjmuje zapytanie (`request`) i zwraca (`return`) metodę zwaną `render`, której zadaniem jest wyrenderowanie (złożenie w całość) naszego szablonu `blog/post_list.html`.
+Jak widzisz, zdefiniowałyśmy (`def`) funkcję zwaną `post_list`, która przyjmuje zapytanie (`request`) i zwraca (`return`) wynik funkcji zwanej `render`, której zadaniem jest wyrenderowanie (złożenie w całość) naszego szablonu `blog/post_list.html`.
 
 Zapisz plik, przejdź do http://127.0.0.1:8000/ i sprawdź, co teraz się stanie.
 

--- a/pl/dynamic_data_in_templates/README.md
+++ b/pl/dynamic_data_in_templates/README.md
@@ -15,7 +15,7 @@ def post_list(request):
     return render(request, 'blog/post_list.html', {})
 ```
 
-Pamiętasz, jak rozmawiałyśmy o dołączaniu kodu zapisanego w odrębnych plikach? Teraz jest przyszedł czas na dołączenie modelu, który napisałyśmy wcześniej w `models.py`. Dodajmy wiersz `from .models import Post` w następujący sposób:
+Pamiętasz, jak rozmawiałyśmy o dołączaniu kodu zapisanego w odrębnych plikach? Teraz przyszedł czas na dołączenie modelu, który napisałyśmy wcześniej w `models.py`. Dodajmy wiersz `from .models import Post` w następujący sposób:
 
 ```python
 from django.shortcuts import render

--- a/pl/extend_your_application/README.md
+++ b/pl/extend_your_application/README.md
@@ -34,10 +34,6 @@ Zaczniemy od dodania linku wewnątrz pliku `blog/templates/blog/post_list.html`.
 <h1><a href="{% url 'post_detail' pk=post.pk %}">{{ post.title }}</a></h1>
 ```
 
-{% raw %}Czas by wyjaśnić co oznacza tajemnicze `{% url 'post_detail' pk=post.pk %}`. Jak można podejrzewać, zapis `{% %}` oznacza, że używamy tagów szablonu Django. Tym razem używamy takiego, który generuje za nas adres strony.{% endraw %}
-
-`blog.views.post_detail` to ścieżka do *widoku* `post_detail`, który chcemy stworzyć. Zwróć uwagę: `blog` to nazwa Twojej aplikacji (folder `blog`), `views` pochodzi od nazwy pliku `views.py`, zaś ostatnia część - `post_detail` - to nazwa naszego *widoku*.
-
 Teraz, gdy wejdziemy na adres http://127.0.0.1:8000/ ujrzymy błąd (co było do przewidzenia, bo nie mamy jeszcze ustawionego adresu URL ani *widoku* dla `post_detail`). Będzie to wyglądać tak:
 
 ![Błąd NoReverseMatch][1]
@@ -67,6 +63,12 @@ Ten fragment `^post/(?P<pk>[0-9]+)/$` wygląda trochę przerażająco, ale spoko
 To oznacza, że gdy wpiszesz w przeglądarce adres `http://127.0.0.1:8000/post/5/`, Django zrozumie, że potrzebujesz *widoku* zwanego `post_detail` i przekaże temu *widokowi* informację, że `pk` jest równe `5`.
 
 `pk` to skrót od `primary key` (ang. klucz główny). Nazwa ta jest często używana w projektach Django. Ale możesz nazwać tę zmienną jak Ci się żywnie podoba (tylko pamiętaj: same małe litery i znak `_` zamiast spacji!). Dla przykładu, zamiast `(?P<pk>[0-9]+)` możemy mieć zmienną `post_id`. Wówczas ten fragment wyglądałby tak: `(?P<post_id>[0-9]+)`.
+
+{% raw %}Czas by wyjaśnić co oznaczało tajemnicze `{% url 'post_detail' pk=post.pk %}`. Jak można podejrzewać, zapis `{% %}` oznacza, że używamy tagów szablonu Django. `url` to taki tag, który generuje za nas adres strony.
+`'post_detail'` to ten sam napis, którego użyliśmy w `urls.py` jako `name`:
+      url(r'^post/(?P<pk>[0-9]+)/$', views.post_detail, name='post_detail'), 
+Dzięki temu Django wie, z którego wzorca zbudować adres URL. Wie zatem, że chodzi nam o coś co zaczyna się od `"post/"` potem ma liczbę `pk` a na końcu `"/"`. Jedyne czego nie wie, to jaką wartość ma mieć `pk`? Właśnie po to podajemy `pk=post.pk`, co oznacza, że `pk` ma być równe kluczowi głównemu naszego posta.
+{% endraw %}
 
 OK, dodałyśmy nowy wzorzec URL do `blog/urls.py`! Odświeżmy stronę: http://127.0.0.1:8000/ Bum! Znowu błąd! Tak jak myślałyśmy!
 

--- a/pl/python_introduction/README.md
+++ b/pl/python_introduction/README.md
@@ -24,7 +24,11 @@ Chcemy otworzyć konsolę Pythona. Wpisz `python`, jeśli pracujesz na Windowsie
 
 Po uruchomieniu Pythona, wiersz poleceń wygląda tak: `>>>`. Jest to sygnał dla nas, że od tego momentu możemy używać wyłącznie instrukcji języka Python. Nie musisz za każdym razem wpisywać `>>>` - Python zrobi to za Ciebie.
 
-Jeśli w którymkolwiek momencie zechcesz wyjść z konsoli Pythona, po prostu wpisz polecenie `exit()` albo użyj kombinacji klawiszy `Ctrl + Z` w Windows lub `Ctrl + D` w Macu/Linuksie. Nie będziesz już więcej widzieć promptu `>>>`.
+Jeśli w którymkolwiek momencie zechcesz wyjść z konsoli Pythona, po prostu wpisz polecenie `exit()` i naciśnij enter. Alternatywnie, możesz użyć kombinacji klawiszy:
+- `Ctrl + C` w Windows lub, jeśli nie zadziałało, to `Ctrl + Z` a potem Enter (kombinacja zależy od wersji Pythona i Windowsa), albo
+- `Ctrl + D` w Macu/Linuksie.
+
+Po udanym wyłączeniu konsoli Pythona, nie będziesz już więcej widzieć promptu `>>>` na początku nowej linii.
 
 Teraz jednak nie chcemy wychodzić z konsoli Pythona. Chcemy za jej pomocą nauczyć się czegoś nowego. Zaczniemy od czegoś bardzo prostego. Spróbuj wpisać jakieś działanie matematyczne, np. `2 + 3`, i wciśnij `Enter`.
 


### PR DESCRIPTION
While preparing to workshops in Wrocław, Poland, I went trough whole tutorial on Windows 10, and found some places which could be phrased better to minimize friction.
The most important one is probably the issue with `ALLOWED_HOSTS` in settings.py, which perhaps should be reflected also in other language versions.
Other than that:
- I've fixed the keyboard shortcut for exiting from Python 3.4 on Windows 8+ according to 
https://stackoverflow.com/a/41524896/575699 and my experience.
- added some rough explanation of why we use `virtualenv` on PythonAnywhere but `venv` on localhost, based on https://www.reddit.com/r/learnpython/comments/4hsudz/pyvenv_vs_virtualenv/
- replaced some of uses of word "method" with "function" to match the distinction between the two introduced in the Introduction to Python and common consensus https://stackoverflow.com/questions/155609/difference-between-a-method-and-a-function (there are still many occurences of "method" in other places of tutorial, but I've changed only these which were in the paragrahps I had to change anyway for other reasons)
- explained that the warning/promt from collectstatic will probably not occur on the first call (or rather: explained that the promt will be shown on subsequent calls)
- fixed the part which said that "the post_details returns render" to "the post_details returns the result of render"
- changed `<QuerySet [<Post: My second post>, <Post: My first post>]>` to the actually shown `[<Post: My second post>, <Post: My first post>]` 
- fixed explanation for the `url` Django tag, moving it a bit further, so we have required background to actually explain what all of the parts of it mean