### PR TITLE
changed sectionx setting to make dropdowns neater

### DIFF
--- a/book.json
+++ b/book.json
@@ -36,6 +36,9 @@
             "url": "https://store.djangogirls.org/",
             "description": "💖 Support our work and buy a Django Girls t-shirt! ✨",
             "btnText": "Get a t-shirt!"
+        },
+        "sectionx": {
+            "tag": "b"
         }
     }
 }


### PR DESCRIPTION
The `sectionx` plugin now has a `tag` setting that defines the tag to use for the dropdown headers. Changing it to `b` tags means they take up less space and look a bit neater.

Addresses #1058 
