### PR TITLE
Added unique prefixes to each os-depedent section so that heading lin…

### DIFF
--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -2,7 +2,7 @@ Git is a "version control system" used by a lot of programmers. This software ca
 
 ## Installing Git
 
-<!--sec data-title="Windows" data-id="git_install_windows"
+<!--sec data-title="Installing Git: Windows" data-id="git_install_windows"
 data-collapse=true ces-->
 
 You can download Git from [git-scm.com](https://git-scm.com/). You can hit "next" on all steps except for one; in the fifth step entitled "Adjusting your PATH environment", choose "Use Git and optional Unix tools from the Windows Command Prompt" (the bottom option). Other than that, the defaults are fine. Checkout Windows-style, commit Unix-style line endings is good.
@@ -10,7 +10,7 @@ You can download Git from [git-scm.com](https://git-scm.com/). You can hit "next
 Do not forget to restart the command prompt or powershell after the installation finished successfully.
 <!--endsec-->
 
-<!--sec data-title="OS X" data-id="git_install_OSX"
+<!--sec data-title="Installing Git: OS X" data-id="git_install_OSX"
 data-collapse=true ces-->
 
 Download Git from [git-scm.com](https://git-scm.com/) and just follow the instructions.
@@ -19,7 +19,7 @@ Download Git from [git-scm.com](https://git-scm.com/) and just follow the instru
 
 <!--endsec-->
 
-<!--sec data-title="Debian or Ubuntu" data-id="git_install_debian_ubuntu"
+<!--sec data-title="Installing Git: Debian or Ubuntu" data-id="git_install_debian_ubuntu"
 data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
@@ -29,7 +29,7 @@ $ sudo apt-get install git
 
 <!--endsec-->
 
-<!--sec data-title="Fedora" data-id="git_install_fedora"
+<!--sec data-title="Installing Git: Fedora" data-id="git_install_fedora"
 data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
@@ -39,7 +39,7 @@ $ sudo dnf install git
 
 <!--endsec-->
 
-<!--sec data-title="openSUSE" data-id="git_install_openSUSE"
+<!--sec data-title="Installing Git: openSUSE" data-id="git_install_openSUSE"
 data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}

--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -31,7 +31,7 @@ We will make a virtualenv called `myvenv`. The general command will be in the fo
 $ python3 -m venv myvenv
 ```
 
-<!--sec data-title="Windows" data-id="virtualenv_installation_windows"
+<!--sec data-title="Virtual environment: Windows" data-id="virtualenv_installation_windows"
 data-collapse=true ces-->
 
 To create a new `virtualenv`, you need to open the command prompt and run `python -m venv myvenv`. It will look like this:
@@ -45,7 +45,7 @@ Where `myvenv` is the name of your `virtualenv`. You can use any other name, but
 
 <!--endsec-->
 
-<!--sec data-title="Linux and OS X" data-id="virtualenv_installation_linuxosx"
+<!--sec data-title="Virtual environment: Linux and OS X" data-id="virtualenv_installation_linuxosx"
 data-collapse=true ces-->
 
 Creating a `virtualenv` on both Linux and OS X is as simple as running `python3 -m venv myvenv`.
@@ -108,7 +108,7 @@ $ python3 -m venv myvenv
 
 The command above will create a directory called `myvenv` (or whatever name you chose) that contains our virtual environment (basically a bunch of directory and files).
 
-<!--sec data-title="Windows" data-id="virtualenv_windows"
+<!--sec data-title="Working with virtualenv: Windows" data-id="virtualenv_windows"
 data-collapse=true ces-->
 
 Start your virtual environment by running:
@@ -129,7 +129,7 @@ C:\Users\Name\djangogirls> myvenv\Scripts\activate
 
 <!--endsec-->
 
-<!--sec data-title="Linux and OS X" data-id="virtualenv_linuxosx"
+<!--sec data-title="Working with virtualenv: Linux and OS X" data-id="virtualenv_linuxosx"
 data-collapse=true ces-->
 
 Start your virtual environment by running:
@@ -178,14 +178,14 @@ Installing collected packages: django
 Successfully installed django-1.11.3
 ```
 
-<!--sec data-title="Windows" data-id="django_err_windows"
+<!--sec data-title="Installing Django: Windows" data-id="django_err_windows"
 data-collapse=true ces-->
 
 > If you get an error when calling pip on Windows platform, please check if your project pathname contains spaces, accents or special characters (for example, `C:\Users\User Name\djangogirls`). If it does, please consider using another place without spaces, accents or special characters (suggestion: `C:\djangogirls`). Create a new virtualenv in the new directory, then delete the old one and try the above command again. (Moving the virtualenv directory won't work since virtualenv uses absolute paths.)
 
 <!--endsec-->
 
-<!--sec data-title="Windows 8 and Windows 10" data-id="django_err_windows8and10"
+<!--sec data-title="Installing Django: Windows 8 and Windows 10" data-id="django_err_windows8and10"
 data-collapse=true ces-->
 
 > Your command line might freeze after when you try to install Django. If this happens, instead of the above command use:
@@ -197,7 +197,7 @@ data-collapse=true ces-->
 
 <!--endsec-->
 
-<!--sec data-title="Linux" data-id="django_err_linux"
+<!--sec data-title="Installing Django: Linux" data-id="django_err_linux"
 data-collapse=true ces-->
 
 > If you get an error when calling pip on Ubuntu 12.04 please run `python -m pip install -U --force-reinstall pip` to fix the pip installation in the virtualenv.

--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -16,7 +16,7 @@ The names of some files and directories are very important for Django. You shoul
 > Remember to run everything in the virtualenv. If you don't see a prefix `(myvenv)` in your console, you need to activate your virtualenv. We explained how to do that in the __Django installation__ chapter in the __Working with virtualenv__ part. Typing `myvenv\Scripts\activate` on Windows or
 `source myvenv/bin/activate` on Mac OS X or Linux will do this for you.
 
-<!--sec data-title="OS X or Linux" data-id="django_start_project_OSX_Linux" data-collapse=true ces-->
+<!--sec data-title="Create project: OS X or Linux" data-id="django_start_project_OSX_Linux" data-collapse=true ces-->
 
 In your Mac OS X or Linux console, you should run the following command. **Don't forget to add the period (or dot) `.` at the end!**
 
@@ -32,7 +32,7 @@ The `(myvenv) ~/djangogirls$` part shown here is just example of the prompt that
 
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="django_start_project_windows" data-collapse=true ces-->
+<!--sec data-title="Create project: Windows" data-id="django_start_project_windows" data-collapse=true ces-->
 
 On Windows you should run the following command. **(Don't forget to add the period (or dot) `.` at the end)**:
 

--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -19,7 +19,7 @@ The window, which is usually called the __command line__ or __command-line inter
 To start some experiments we need to open our command-line interface first.
 
 
-<!--sec data-title="Windows" data-id="windows_prompt" data-collapse=true ces-->
+<!--sec data-title="Opening: Windows" data-id="windows_prompt" data-collapse=true ces-->
 
 Go to Start menu → Windows System → Command Prompt.
 
@@ -28,13 +28,13 @@ Go to Start menu → Windows System → Command Prompt.
 <!--endsec-->
 
 
-<!--sec data-title="OS X" data-id="OSX_prompt" data-collapse=true ces-->
+<!--sec data-title="Opening: OS X" data-id="OSX_prompt" data-collapse=true ces-->
 
 Go to Applications → Utilities → Terminal.
 
 <!--endsec-->
 
-<!--sec data-title="Linux" data-id="linux_prompt" data-collapse=true ces-->
+<!--sec data-title="Opening: Linux" data-id="linux_prompt" data-collapse=true ces-->
 
 It's probably under Applications → Accessories → Terminal, but that may depend on your system. If it's not there, just Google it. :)
 
@@ -44,7 +44,7 @@ It's probably under Applications → Accessories → Terminal, but that may depe
 
 You now should see a white or black window that is waiting for your commands.
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_prompt" data-collapse=true ces-->
+<!--sec data-title="Prompt: OS X and Linux" data-id="OSX_Linux_prompt" data-collapse=true ces-->
 
 
 If you're on Mac or Linux, you probably see `$`, just like this:
@@ -55,7 +55,7 @@ $
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="windows_prompt2" data-collapse=true ces-->
+<!--sec data-title="Prompt: Windows" data-id="windows_prompt2" data-collapse=true ces-->
 
 
 On Windows, it's a `>` sign, like this:
@@ -78,7 +78,7 @@ In the tutorial, when we want you to type in a command, we will include the `$` 
 
 Let's start with something simple. Type this command:
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_whoami" data-collapse=true ces-->
+<!--sec data-title="Your first command: OS X and Linux" data-id="OSX_Linux_whoami" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -88,7 +88,7 @@ $ whoami
 <!--endsec-->
 
 
-<!--sec data-title="Windows" data-id="windows_whoami" data-collapse=true ces-->
+<!--sec data-title="Your first command: Windows" data-id="windows_whoami" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -117,7 +117,7 @@ Each operating system has a slightly different set of commands for the command l
 
 It'd be nice to know where are we now, right? Let's see. Type this command and hit `enter`:
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_pwd" data-collapse=true ces-->
+<!--sec data-title="Current directory: OS X and Linux" data-id="OSX_Linux_pwd" data-collapse=true ces-->
 
 
 {% filename %}command-line{% endfilename %}
@@ -131,7 +131,7 @@ $ pwd
 <!--endsec-->
 
 
-<!--sec data-title="Windows" data-id="windows_cd" data-collapse=true ces-->
+<!--sec data-title="Current directory: Windows" data-id="windows_cd" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -150,7 +150,7 @@ You'll probably see something similar on your machine. Once you open the command
 
 So what's in it? It'd be cool to find out. Let's see:
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_ls" data-collapse=true ces-->
+<!--sec data-title="List files and directories: OS X and Linux" data-id="OSX_Linux_ls" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -163,7 +163,7 @@ Music
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="windows_dir" data-collapse=true ces-->
+<!--sec data-title="List files and directories: Windows" data-id="windows_dir" data-collapse=true ces-->
 
 
 {% filename %}command-line{% endfilename %}
@@ -185,7 +185,7 @@ Music
 
 Now, let's go to our Desktop directory:
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_move_to" data-collapse=true ces-->
+<!--sec data-title="Change current directory: OS X and Linux" data-id="OSX_Linux_move_to" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -193,7 +193,7 @@ $ cd Desktop
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="windows_move_to" data-collapse=true ces-->
+<!--sec data-title="Change current directory: Windows" data-id="windows_move_to" data-collapse=true ces-->
 
 
 {% filename %}command-line{% endfilename %}
@@ -204,7 +204,7 @@ $ cd Desktop
 
 Check if it's really changed:
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_pwd2" data-collapse=true ces-->
+<!--sec data-title="Check if changed: OS X and Linux" data-id="OSX_Linux_pwd2" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -213,7 +213,7 @@ $ pwd
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="windows_cd2" data-collapse=true ces-->
+<!--sec data-title="Check if changed: Windows" data-id="windows_cd2" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -232,7 +232,7 @@ Here it is!
 
 How about creating a practice directory on your desktop? You can do it this way:
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_mkdir" data-collapse=true ces-->
+<!--sec data-title="Create directory: OS X and Linux" data-id="OSX_Linux_mkdir" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -240,7 +240,7 @@ $ mkdir practice
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="windows_mkdir" data-collapse=true ces-->
+<!--sec data-title="Create directory: Windows" data-id="windows_mkdir" data-collapse=true ces-->
 
 
 {% filename %}command-line{% endfilename %}
@@ -261,7 +261,7 @@ A small challenge for you: in your newly created `practice` directory, create a 
 
 #### Solution:
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_test_dir" data-collapse=true ces-->
+<!--sec data-title="Exercise solution: OS X and Linux" data-id="OSX_Linux_test_dir" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -272,7 +272,7 @@ test
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="windows_test_dir" data-collapse=true ces-->
+<!--sec data-title="Exercise solution: Windows" data-id="windows_test_dir" data-collapse=true ces-->
 
 
 {% filename %}command-line{% endfilename %}
@@ -294,7 +294,7 @@ We don't want to leave a mess, so let's remove everything we did until that poin
 
 First, we need to get back to Desktop:
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_back" data-collapse=true ces-->
+<!--sec data-title="Clean up: OS X and Linux" data-id="OSX_Linux_back" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -302,7 +302,7 @@ $ cd ..
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="windows_back" data-collapse=true ces-->
+<!--sec data-title="Clean up: Windows" data-id="windows_back" data-collapse=true ces-->
 
 
 {% filename %}command-line{% endfilename %}
@@ -315,7 +315,7 @@ Using `..` with the `cd` command will change your current directory to the paren
 
 Check where you are:
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_pwd3" data-collapse=true ces-->
+<!--sec data-title="Check location: OS X and Linux" data-id="OSX_Linux_pwd3" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -324,7 +324,7 @@ $ pwd
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="windows_cd3" data-collapse=true ces-->
+<!--sec data-title="Check location: Windows" data-id="windows_cd3" data-collapse=true ces-->
 
 
 {% filename %}command-line{% endfilename %}
@@ -338,7 +338,7 @@ Now time to delete the `practice` directory:
 
 > __Attention__: Deleting files using `del`, `rmdir` or `rm` is irrecoverable, meaning _the deleted files will be gone forever_! So be very careful with this command.
 
-<!--sec data-title="Windows Powershell, OS X and Linux" data-id="OSX_Linux_rm" data-collapse=true ces-->
+<!--sec data-title="Delete directory: Windows Powershell, OS X and Linux" data-id="OSX_Linux_rm" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -346,7 +346,7 @@ $ rm -r practice
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows Command Prompt" data-id="windows_rmdir" data-collapse=true ces-->
+<!--sec data-title="Delete directory: Windows Command Prompt" data-id="windows_rmdir" data-collapse=true ces-->
 
 
 {% filename %}command-line{% endfilename %}
@@ -358,7 +358,7 @@ practice, Are you sure <Y/N>? Y
 
 Done! To be sure it's actually deleted, let's check it:
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_ls2" data-collapse=true ces-->
+<!--sec data-title="Check deletion: OS X and Linux" data-id="OSX_Linux_ls2" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -366,7 +366,7 @@ $ ls
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="windows_dir2" data-collapse=true ces-->
+<!--sec data-title="Check deletion: Windows" data-id="windows_dir2" data-collapse=true ces-->
 
 
 {% filename %}command-line{% endfilename %}
@@ -379,7 +379,7 @@ $ ls
 
 That's it for now! You can safely close the command line now. Let's do it the hacker way, alright? :)
 
-<!--sec data-title="OS X and Linux" data-id="OSX_Linux_exit" data-collapse=true ces-->
+<!--sec data-title="Exit: OS X and Linux" data-id="OSX_Linux_exit" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -387,7 +387,7 @@ $ exit
 ```
 <!--endsec-->
 
-<!--sec data-title="Windows" data-id="windows_exit" data-collapse=true ces-->
+<!--sec data-title="Exit: Windows" data-id="windows_exit" data-collapse=true ces-->
 
 
 {% filename %}command-line{% endfilename %}

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -5,7 +5,7 @@
 Django is written in Python. We need Python to do anything in Django. Let's start by installing it! We want you to install Python 3.6, so if you have any earlier version, you will need to upgrade it.
 
 
-<!--sec data-title="Windows" data-id="python_windows" data-collapse=true ces-->
+<!--sec data-title="Install Python: Windows" data-id="python_windows" data-collapse=true ces-->
 
 First check whether your computer is running a 32-bit version or a 64-bit version of Windows, by pressing the Windows key + Pause/Break key which will open your System info, and look at the "System type" line. You can download Python for Windows from the website https://www.python.org/downloads/windows/. Click on the "Latest Python 3 Release - Python x.x.x" link. If your computer is running a **64-bit** version of Windows, download the **Windows x86-64 executable installer**. Otherwise, download the **Windows x86 executable installer**. After downloading the installer, you should run it (double-click on it) and follow the instructions there.
 
@@ -27,7 +27,7 @@ If you install an older version of Python, the installation screen may look a bi
 
 <!--endsec-->
 
-<!--sec data-title="OS X" data-id="python_OSX"
+<!--sec data-title="Install Python: OS X" data-id="python_OSX"
 data-collapse=true ces-->
 
 > **Note** Before you install Python on OS X, you should ensure your Mac settings allow installing packages that aren't from the App Store. Go to System Preferences (it's in the Applications folder), click "Security & Privacy," and then the "General" tab. If your "Allow apps downloaded from:" is set to "Mac App Store," change it to "Mac App Store and identified developers."
@@ -39,7 +39,7 @@ You need to go to the website https://www.python.org/downloads/release/python-36
 
 <!--endsec-->
 
-<!--sec data-title="Linux" data-id="python_linux"
+<!--sec data-title="Install Python: Linux" data-id="python_linux"
 data-collapse=true ces-->
 
 It is very likely that you already have Python installed out of the box. To check if you have it installed (and which version it is), open a console and type the following command:
@@ -55,8 +55,7 @@ If you have a different 'micro version' of Python installed, e.g. 3.6.0, then yo
 
 <!--endsec-->
 
-<!--sec data-title="Debian or Ubuntu" data-id="python_debian"
-data-collapse=true ces-->
+<!--sec data-title="Install Python: Debian or Ubuntu" data-id="python_debian" data-collapse=true ces-->
 
 Type this command into your console:
 
@@ -67,7 +66,7 @@ $ sudo apt-get install python3.6
 
 <!--endsec-->
 
-<!--sec data-title="Fedora" data-id="python_fedora"
+<!--sec data-title="Install Python: Fedora" data-id="python_fedora"
 data-collapse=true ces-->
 
 Use this command in your console:
@@ -81,7 +80,7 @@ If you're on older Fedora versions you might get an error that the command dnf i
 
 <!--endsec-->
 
-<!--sec data-title="openSUSE" data-id="python_openSUSE"
+<!--sec data-title="Install Python: openSUSE" data-id="python_openSUSE"
 data-collapse=true ces-->
 
 Use this command in your console:

--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -584,7 +584,7 @@ Now we need to save the file and give it a descriptive name. Let's call the file
 
 With the file saved, it's time to run it! Using the skills you've learned in the command line section, use the terminal to **change directories** to the desktop.
 
-<!--sec data-title="OS X" data-id="python_OSX"
+<!--sec data-title="Change directory: OS X" data-id="python_OSX"
 data-collapse=true ces-->
 
 On a Mac, the command will look something like this:
@@ -595,7 +595,7 @@ $ cd ~/Desktop
 ```
 <!--endsec-->
 
-<!--sec data-title="Linux" data-id="python_linux"
+<!--sec data-title="Change directory: Linux" data-id="python_linux"
 data-collapse=true ces-->
 
 On Linux, it will be like this (the word "Desktop" might be translated to your local language):
@@ -607,7 +607,7 @@ $ cd ~/Desktop
 
 <!--endsec-->
 
-<!--sec data-title="Windows Command Prompt" data-id="python_windows" data-collapse=true ces-->
+<!--sec data-title="Change directory: Windows Command Prompt" data-id="python_windows" data-collapse=true ces-->
 
 On Windows Command Prompt, it will be like this:
 
@@ -618,7 +618,7 @@ On Windows Command Prompt, it will be like this:
 <!--endsec-->
 
 
-<!--sec data-title="Windows Powershell" data-id="python_windowsPSH" data-collapse=true ces-->
+<!--sec data-title="Change directory: Windows Powershell" data-id="python_windowsPSH" data-collapse=true ces-->
 
 And on Windows Powershell, it will be like this:
 


### PR DESCRIPTION
Quick fix for #1089 . Heading anchor ids for dropdown sections are based on the titles, which weren't unique, so linking to them didn't work. You can reference the `div` id defined by the `data-id` property, but the permalinks that appear next to the headings unfortunately don't use this.

Prefixing each dropdown title with the page section title was the least confusing way I could think of to fix this. I've only updated English so far, but if approved I'll update the other languages.
