### PR TITLE
Clarify simplest view example

### DIFF
--- a/en/django_views/README.md
+++ b/en/django_views/README.md
@@ -21,7 +21,7 @@ Not too much stuff here yet.
 
 Remember that lines starting with `#` are comments – this means that those lines won't be run by Python.
 
-Let's create a view as the comment suggests. Add the following minimal view below it:
+Let's create a *view* as the comment suggests. Add the following minimal view below it:
 
 {% filename %}blog/views.py{% endfilename %}
 ```python

--- a/en/django_views/README.md
+++ b/en/django_views/README.md
@@ -21,14 +21,12 @@ Not too much stuff here yet.
 
 Remember that lines starting with `#` are comments – this means that those lines won't be run by Python.
 
-The simplest *view* can look like this:
+Let's create a view as the comment suggests. Add the following minimal view below it:
 
 {% filename %}blog/views.py{% endfilename %}
 ```python
-from django.shortcuts import render
-
 def post_list(request):
-    return render(request, 'blog/post_list.html', {})
+    return render(request, 'blog/post_list.html')
 ```
 
 As you can see, we created a function (`def`) called `post_list` that takes `request` and `return` a function `render` that will render (put together) our template `blog/post_list.html`.

--- a/en/django_views/README.md
+++ b/en/django_views/README.md
@@ -25,6 +25,8 @@ The simplest *view* can look like this:
 
 {% filename %}blog/views.py{% endfilename %}
 ```python
+from django.shortcuts import render
+
 def post_list(request):
     return render(request, 'blog/post_list.html', {})
 ```


### PR DESCRIPTION
It's not true that the "simplest" *view* can look like this, because the import will still be needed. I am aware that it is mentioned before but one of the girls in my group removed it, since that's apparently the simplest the *view* can look like :).

Changes in this pull request:

- Add required import to view example
