### PR TITLE
fixed error message of TypeError for unorderable types

### DIFF
--- a/cs/python_introduction/README.md
+++ b/cs/python_introduction/README.md
@@ -444,7 +444,7 @@ Už jsi někdy slyšela výraz "srovnávat jablka a hrušky"? Zkusme v Pythonu e
 >>> 1 > 'django'
 Traceback (most recent call last):
 File "<stdin>", line 1, in <module>
-TypeError: unorderable types: int() > str()
+TypeError: '>' not supported between instances of 'int' and 'str'
 ```
 
 Zde vidíš, že stejně jako nelze srovnávat "jablka a hrušky", Python není schopen porovnávat řetězce (`str`) a čísla (`int`). Místo toho zobrazí **TypeError** a říká nám, že tyto dva typy nelze srovnávat společně.

--- a/de/python_introduction/README.md
+++ b/de/python_introduction/README.md
@@ -447,7 +447,7 @@ Die Redewendung "Äpfel mit Birnen zu vergleichen" hast du bestimmt schon einmal
 >>> 1 > 'django'
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-TypeError: unorderable types: int() > str()
+TypeError: '>' not supported between instances of 'int' and 'str'
 ```
 
 Unterschiedliche Dinge, hier die Datentypen Zahlen (`int`) und Strings (`str`), lassen sich auch in Python nicht miteinander vergleichen. In solch einem Fall liefert uns Python einen **TypeError** und sagt uns, dass diese zwei Datentypen nicht miteinander verglichen werden können.

--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -503,7 +503,7 @@ Have you heard of the expression "comparing apples to oranges"? Let's try the Py
 >>> 1 > 'django'
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-TypeError: unorderable types: int() > str()
+TypeError: '>' not supported between instances of 'int' and 'str'
 ```
 
 Here you see that just like in the expression, Python is not able to compare a number (`int`) and a string (`str`).

--- a/es/python_introduction/README.md
+++ b/es/python_introduction/README.md
@@ -397,7 +397,7 @@ Puedes darle a Python todos los números para comparar que quieras, y siempre te
     >>> 1 > 'django'
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    TypeError: unorderable types: int() > str()
+    TypeError: '>' not supported between instances of 'int' and 'str'
     
 
 Aquí verás que al igual que en la expresión, Python no es capaz de comparar un número (`int`) y un string (`str`). En cambio, muestra un **TypeError** y nos dice que los dos tipos no se pueden comparar.

--- a/fr/python_introduction/README.md
+++ b/fr/python_introduction/README.md
@@ -445,7 +445,7 @@ Vous connaissez l'expression "on ne compare pas les choux et les carottes" ? Ess
 >>> 1 > 'django'
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-TypeError: unorderable types: int() > str()
+TypeError: '>' not supported between instances of 'int' and 'str'
 ```
 
 Comme vous le voyez, Python n'est pas capable de comparer un nombre (`int`) et une chaîne de caractères (`str`). À la place, il nous montre une **TypeError** et nous dit que les deux types ne peuvent pas être comparés.

--- a/hu/python_introduction/README.md
+++ b/hu/python_introduction/README.md
@@ -410,7 +410,7 @@ Hallottad már azt a kifejezést hogy "almákat narancsokkal összehasonlítani"
     >>> 1 > 'django'
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    TypeError: unorderable types: int() > str()
+    TypeError: '>' not supported between instances of 'int' and 'str'
     
 
 Láthatod, hogy ugyanúgy, mint a kifejezéseknél, a Python nem tudja összehasonlítani a számot (`int`) a stringgel (`str`). Ehelyett **TypeError** típusú hibát dob, azaz megmondja, hogy két különböző típust nem lehet egymással összehasonlítani.

--- a/it/python_introduction/README.md
+++ b/it/python_introduction/README.md
@@ -406,7 +406,7 @@ Hai sentito parlare dell'espressione "comparare mele e arance"? Proviamo l'equiv
     >>> 1 > 'django'
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    TypeError: unorderable types: int() > str()
+    TypeError: '>' not supported between instances of 'int' and 'str'
     
 
 Dall'espressione puoi capire che Python non è in grado di mettere a confronto un numero (`int`) e una stringa (`str`). Ci mostra invece un **TypeError** e ci dice che i due tipi non possono essere messi a confronto.

--- a/ko/python_introduction/README.md
+++ b/ko/python_introduction/README.md
@@ -505,7 +505,7 @@ True
 >>> 1 > 'django'
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-TypeError: unorderable types: int() > str()
+TypeError: '>' not supported between instances of 'int' and 'str'
 ```
 
 이처럼 파이썬은 숫자(`int`)와 문자열(`str`)을 비교할 수 없어요. 대신 **TypeError**를 보여줘 두 타입이 서로 비교 대상이 아니라는 것을 알려줍니다.

--- a/pl/python_introduction/README.md
+++ b/pl/python_introduction/README.md
@@ -425,7 +425,7 @@ Znasz powiedzenie "porównywać jabłka z gruszkami"? Zobaczmy, jak działa jego
     >>> 1 > 'django'
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    TypeError: unorderable types: int() > str()
+    TypeError: '>' not supported between instances of 'int' and 'str'
 
 
 Widać, że podobnie jak w powiedzeniu, Python nie jest w stanie porównać liczby (`int`) ze stringiem (`str`). Zamiast tego zwraca nam **TypeError** i mówi nam, że te dwa typy nie mogą być porównywane ze sobą.

--- a/pt/python_introduction/README.md
+++ b/pt/python_introduction/README.md
@@ -503,7 +503,7 @@ Já ouviu a expressão "comparar maçãs com laranjas"? Vamos tentar o equivalen
 >>> 1 > 'django'
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-TypeError: unorderable types: int() > str()
+TypeError: '>' not supported between instances of 'int' and 'str'
 ```
 
 Aqui vemos que assim como na expressão, Python não é capaz de comparar um número (`int`) e uma string (`str`).

--- a/ru/python_introduction/README.md
+++ b/ru/python_introduction/README.md
@@ -504,7 +504,7 @@ True
 >>> 1 > 'django'
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-TypeError: unorderable types: int() > str()
+TypeError: '>' not supported between instances of 'int' and 'str'
 ```
 
 Как мы видим, Python не знает, как сравнить число (`int`) и строку (`str`) между собой. Поэтому он просто возвращает нам ошибку **TypeError** и предупреждает, что объекты заданных типов не могут быть сравнены.

--- a/sk/python_introduction/README.md
+++ b/sk/python_introduction/README.md
@@ -443,7 +443,7 @@ Už ste počula výraz "porovnávať hrušky s jablkami"? Skúsme pythonský ekv
 >>> 1 > 'django'
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-TypeError: unorderable types: int() > str()
+TypeError: '>' not supported between instances of 'int' and 'str'
 ```
 
 Tu vidíš, že tak ako nevieme porovnávať hrušky s jablkami, ani Python neviem porovnať číslo (`int`) s reťazcom (`str`). Namiesto toho vypíše chybu **TypeError** a povie nám, ktoré dva typy sa nedajú porovnať.

--- a/tr/python_introduction/README.md
+++ b/tr/python_introduction/README.md
@@ -446,7 +446,7 @@ Portakallarla elmaları karşılaştılaştırabilir miyiz? Bunun Python'daki e�
 >>> 1 > 'django'
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-TypeError: unorderable types: int() > str()
+TypeError: '>' not supported between instances of 'int' and 'str'
 ```    
 
 Gördüğünüz gibi Python tam sayılar(`int`) ve kelimeleri(yani stringleri, `str`) karşılaştıramıyor. Onun yerine, **TypeError** göstererek iki farklı tipteki değişkenin karşılaştırılamayacağını söylüyor. 

--- a/uk/python_introduction/README.md
+++ b/uk/python_introduction/README.md
@@ -373,7 +373,7 @@
     >>> 1 > 'django'
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    TypeError: unorderable types: int() > str()
+    TypeError: '>' not supported between instances of 'int' and 'str'
 
 Бачимо тут, що як і у виразі, Python не в змозі порівняти число (`int`) та рядок (`str`).
 Натомість, виводиться **TypeError** і повідомляє нас про те, що ці два типи не можна порівнювати між собою.

--- a/zh/python_introduction/README.md
+++ b/zh/python_introduction/README.md
@@ -406,7 +406,7 @@
     >>> 1 > 'django'
     Traceback (most recent call last):
       File "<stdin>", line 1, in <module>
-    TypeError: unorderable types: int() > str()
+    TypeError: '>' not supported between instances of 'int' and 'str'
     
 
 在这里你看到就像在这表达式中，Python 是不能比较数字 （`int`） 和字符串 （`str`）。 相反，它显示一个 **TypeError**，并告诉我们两个类型不能相互比较。


### PR DESCRIPTION
Old error message is by Python 3.5, new by Python 3.6.

The tutorial now instructs to install Python 3.6, so it should also show the corresponding error messages.