### PR TITLE
Avoiding confusion when sections don't have Windows commands

### DIFF
--- a/en/django_admin/README.md
+++ b/en/django_admin/README.md
@@ -22,11 +22,25 @@ To log in, you need to create a *superuser* - a user account that has control ov
 
 > Remember, to write new commands while the web server is running, open a new terminal window and activate your virtualenv. We reviewed how to write new commands in the <b>Your first Django project!</b> chapter, in the <b>Starting the web server</b> section.
 
-When prompted, type your username (lowercase, no spaces), email address, and password. Don't worry that you can't see the password you're typing in – that's how it's supposed to be. Just type it in and press `enter` to continue. The output should look like this (where the username and email should be your own ones):
+<!--sec data-title="Create superuser: Mac OS X or Linux" data-id="django_create_superuser_osx_linux" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
 (myvenv) ~/djangogirls$ python manage.py createsuperuser
+```
+<!-- endsec -->
+
+<!--sec data-title="Create superuser: Windows" data-id="django_create_superuser_windows" data-collapse=true ces-->
+
+{% filename %}command-line{% endfilename %}
+```
+(myvenv) C:\Users\Name\djangogirls> python manage.py createsuperuser
+```
+<!-- endsec -->
+
+When prompted, type your username (lowercase, no spaces), email address, and password. **Don't worry that you can't see the password you're typing in – that's how it's supposed to be.** Just type it in and press `enter` to continue. The output should look like this (where the username and email should be your own ones):
+
+```
 Username: admin
 Email address: admin@admin.com
 Password:

--- a/en/django_admin/README.md
+++ b/en/django_admin/README.md
@@ -22,7 +22,7 @@ To log in, you need to create a *superuser* - a user account that has control ov
 
 > Remember, to write new commands while the web server is running, open a new terminal window and activate your virtualenv. We reviewed how to write new commands in the <b>Your first Django project!</b> chapter, in the <b>Starting the web server</b> section.
 
-{% filename %}Mac OS X or Linux{% endfilename %}
+{% filename %}Mac OS X or Linux:{% endfilename %}
 ```
 (myvenv) ~/djangogirls$ python manage.py createsuperuser
 ```

--- a/en/django_admin/README.md
+++ b/en/django_admin/README.md
@@ -22,21 +22,15 @@ To log in, you need to create a *superuser* - a user account that has control ov
 
 > Remember, to write new commands while the web server is running, open a new terminal window and activate your virtualenv. We reviewed how to write new commands in the <b>Your first Django project!</b> chapter, in the <b>Starting the web server</b> section.
 
-<!--sec data-title="Create superuser: Mac OS X or Linux" data-id="django_create_superuser_osx_linux" data-collapse=true ces-->
-
-{% filename %}command-line{% endfilename %}
+{% filename %}Mac OS X or Linux{% endfilename %}
 ```
 (myvenv) ~/djangogirls$ python manage.py createsuperuser
 ```
-<!-- endsec -->
 
-<!--sec data-title="Create superuser: Windows" data-id="django_create_superuser_windows" data-collapse=true ces-->
-
-{% filename %}command-line{% endfilename %}
+{% filename %}Windows:{% endfilename %}
 ```
 (myvenv) C:\Users\Name\djangogirls> python manage.py createsuperuser
 ```
-<!-- endsec -->
 
 When prompted, type your username (lowercase, no spaces), email address, and password. **Don't worry that you can't see the password you're typing in – that's how it's supposed to be.** Just type it in and press `enter` to continue. The output should look like this (where the username and email should be your own ones):
 

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -79,7 +79,6 @@ To keep everything tidy, we will create a separate application inside our projec
 {% filename %}command-line{% endfilename %}
 ```
 (myvenv) C:\Users\Name\djangogirls> python manage.py startapp blog
-
 ```
 <!-- endsec -->
 

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -72,21 +72,16 @@ To keep everything tidy, we will create a separate application inside our projec
 ```
 (myvenv) ~/djangogirls$ python manage.py startapp blog
 ```
-
 <!-- endsec -->
 
 <!--sec data-title="Create Blog app: Windows" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
-(myvenv) ~/djangogirls$ python manage.py startapp blog
+(myvenv) C:\Users\Name\djangogirls> python manage.py startapp blog
+
 ```
-
 <!-- endsec -->
-
-
-
-
 
 You will notice that a new `blog` directory is created and it contains a number of files now. The directories and files in our project should look like this:
 

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -66,10 +66,27 @@ You can think of a model in the database as a spreadsheet with columns (fields) 
 
 To keep everything tidy, we will create a separate application inside our project. It is very nice to have everything organized from the very beginning. To create an application we need to run the following command in the console (from `djangogirls` directory where `manage.py` file is):
 
+<!--sec data-title="Create Blog app: Mac OS X or Linux" data-collapse=true ces-->
+
 {% filename %}command-line{% endfilename %}
 ```
 (myvenv) ~/djangogirls$ python manage.py startapp blog
 ```
+
+<!-- endsec -->
+
+<!--sec data-title="Create Blog app: Windows" data-collapse=true ces-->
+
+{% filename %}command-line{% endfilename %}
+```
+(myvenv) ~/djangogirls$ python manage.py startapp blog
+```
+
+<!-- endsec -->
+
+
+
+
 
 You will notice that a new `blog` directory is created and it contains a number of files now. The directories and files in our project should look like this:
 

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -66,21 +66,15 @@ You can think of a model in the database as a spreadsheet with columns (fields) 
 
 To keep everything tidy, we will create a separate application inside our project. It is very nice to have everything organized from the very beginning. To create an application we need to run the following command in the console (from `djangogirls` directory where `manage.py` file is):
 
-<!--sec data-title="Create Blog app: Mac OS X or Linux" data-id="django_blog_app_osx_linux" data-collapse=true ces-->
-
-{% filename %}command-line{% endfilename %}
+{% filename %}MAc OS X and Linux{% endfilename %}
 ```
 (myvenv) ~/djangogirls$ python manage.py startapp blog
 ```
-<!-- endsec -->
 
-<!--sec data-title="Create Blog app: Windows" data-id="django_blog_app_windows" data-collapse=true ces-->
-
-{% filename %}command-line{% endfilename %}
+{% filename %}Windows:{% endfilename %}
 ```
 (myvenv) C:\Users\Name\djangogirls> python manage.py startapp blog
 ```
-<!-- endsec -->
 
 You will notice that a new `blog` directory is created and it contains a number of files now. The directories and files in our project should look like this:
 

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -66,7 +66,7 @@ You can think of a model in the database as a spreadsheet with columns (fields) 
 
 To keep everything tidy, we will create a separate application inside our project. It is very nice to have everything organized from the very beginning. To create an application we need to run the following command in the console (from `djangogirls` directory where `manage.py` file is):
 
-{% filename %}MAc OS X and Linux{% endfilename %}
+{% filename %}Mac OS X and Linux:{% endfilename %}
 ```
 (myvenv) ~/djangogirls$ python manage.py startapp blog
 ```

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -66,7 +66,7 @@ You can think of a model in the database as a spreadsheet with columns (fields) 
 
 To keep everything tidy, we will create a separate application inside our project. It is very nice to have everything organized from the very beginning. To create an application we need to run the following command in the console (from `djangogirls` directory where `manage.py` file is):
 
-<!--sec data-title="Create Blog app: Mac OS X or Linux" data-collapse=true ces-->
+<!--sec data-title="Create Blog app: Mac OS X or Linux" data-id=django_blog_app_osx_linux data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -74,7 +74,7 @@ To keep everything tidy, we will create a separate application inside our projec
 ```
 <!-- endsec -->
 
-<!--sec data-title="Create Blog app: Windows" data-collapse=true ces-->
+<!--sec data-title="Create Blog app: Windows" data-id=django_blog_app_windows data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -66,7 +66,7 @@ You can think of a model in the database as a spreadsheet with columns (fields) 
 
 To keep everything tidy, we will create a separate application inside our project. It is very nice to have everything organized from the very beginning. To create an application we need to run the following command in the console (from `djangogirls` directory where `manage.py` file is):
 
-<!--sec data-title="Create Blog app: Mac OS X or Linux" data-id=django_blog_app_osx_linux data-collapse=true ces-->
+<!--sec data-title="Create Blog app: Mac OS X or Linux" data-id="django_blog_app_osx_linux" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -74,7 +74,7 @@ To keep everything tidy, we will create a separate application inside our projec
 ```
 <!-- endsec -->
 
-<!--sec data-title="Create Blog app: Windows" data-id=django_blog_app_windows data-collapse=true ces-->
+<!--sec data-title="Create Blog app: Windows" data-id="django_blog_app_windows" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```


### PR DESCRIPTION
During PyCon UK Django Girls workshop everyone in my group was using Windows. There was confusion when some sections only had Mac/Linux shell commands. Attendees would then copy/paste or re-type the whole Linux command (including the $ and so on) as they looked different to their Windows shell. Hopefully this fixes some of it going forward.