### PR TITLE
Simplify ALLOWED_HOSTS configuration

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -107,13 +107,13 @@ match our hostname on PythonAnywhere once we deploy our application so we will c
 
 {% filename %}mysite/settings.py{% endfilename %}
 ```python
-ALLOWED_HOSTS = ['127.0.0.1', '<your_username>.pythonanywhere.com']
+ALLOWED_HOSTS = ['127.0.0.1', '.pythonanywhere.com']
 ```
 
 > **Note**: If you're using a Chromebook, add this line at the bottom of your settings.py file:
 > `MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'`
 
-> Also add `django-girls-<your_username>.c9users.io` to the ALLOWED_HOSTS if you are using cloud9
+> Also add `.c9users.io` to the `ALLOWED_HOSTS` if you are using cloud9
 
 ## Set up a database
 


### PR DESCRIPTION
998120bbbdbdc8907f3e1178aadf416b022de5b3 moved from .pythonanywhere.com to <your_username>.pythonanywhere.com to fix a DisallowedHost error. I can't reproduce that and this is much easier because it allows copy-pasting.