### PR TITLE
Added 'on_delete' to 'ForeignKey' in Django models:

### DIFF
--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -121,7 +121,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User',on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(


### PR DESCRIPTION
Not providing `on_delete` will give deprecation warning in Django 1.11 - will be required in Django 2.0.
See https://docs.djangoproject.com/en/1.11/ref/models/fields/#foreignkey

Changes in this pull request:

- Added `on_delete` positional argument to ForeignKey
- May currently alleviate some confusion, and required in upcoming Django 2.0.
