### PR TITLE
%locale% will properly handle crowdin-generated assets

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,3 +1,3 @@
 files:
   - source: /en/**/*.md
-    translation: '**/%original_file_name%'
+    translation: '/%locale%/**/%original_file_name%'


### PR DESCRIPTION
We have setup dialect-grade translations on Crowdin, so we are not able to cover all of them using two letter language code - we need to use full locales.