### PR TITLE
Add %locale% to destination for target languages on Crowdin

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,3 +1,3 @@
 files:
   - source: /en/**/*.md
-    translation: '**/%original_file_name%'
+    translation: '/%locale%/**/%original_file_name%'


### PR DESCRIPTION
I'm reopening this pull request with adding `%locale%` to crowding configuration. It will not help us a lot, but at least resolve an issue with:
![wrong_pattern](https://user-images.githubusercontent.com/1165138/35307910-77c8bfc0-00a5-11e8-996b-f5a023cc35ec.png)
It will also push all Crowdin translations to Github (there's always open pull request, that is automatically open by Crowdin for that, but is useless, as there's almost no possibility that we will merge all languages at the same time) - right now languages that are crashing in two letter code space (we are talking here about `zh-CN`  vs `zh-TW` and `pt-PT` vs `pt-BR`) overwrite each other translations.

To refresh Crowdin and resolve problem there and with overwriting translated assets here @aniav needs to check Github Integration configuration on Crowdin and pause the sync, and resume it.