### PR TITLE
Add on_delete to ForeignKey in Django Models

### DIFF
--- a/cs/django_models/README.md
+++ b/cs/django_models/README.md
@@ -115,7 +115,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User',on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/cs/django_models/README.md
+++ b/cs/django_models/README.md
@@ -115,7 +115,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User',on_delete=models.CASCADE)
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/de/django_models/README.md
+++ b/de/django_models/README.md
@@ -118,7 +118,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -126,7 +126,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User',on_delete=models.CASCADE)
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/es/django_models/README.md
+++ b/es/django_models/README.md
@@ -109,7 +109,7 @@ Vamos abrir `blog/models.py`, quitamos todo y escribimos un código como este:
     from django.utils import timezone
     
     class Post(models.Model):
-        author = models.ForeignKey('auth.User')
+        author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
         title = models.CharField(max_length=200)
         text = models.TextField()
         created_date = models.DateTimeField(

--- a/fr/django_models/README.md
+++ b/fr/django_models/README.md
@@ -111,7 +111,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/hu/django_models/README.md
+++ b/hu/django_models/README.md
@@ -106,7 +106,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/it/django_models/README.md
+++ b/it/django_models/README.md
@@ -106,7 +106,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/ko/django_models/README.md
+++ b/ko/django_models/README.md
@@ -115,7 +115,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/pl/django_models/README.md
+++ b/pl/django_models/README.md
@@ -114,7 +114,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/pt/django_models/README.md
+++ b/pt/django_models/README.md
@@ -121,7 +121,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/sk/django_models/README.md
+++ b/sk/django_models/README.md
@@ -115,7 +115,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/tr/django_models/README.md
+++ b/tr/django_models/README.md
@@ -124,7 +124,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User',on_delete=models.CASCADE)
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/uk/django_models/README.md
+++ b/uk/django_models/README.md
@@ -107,7 +107,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User')
+    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/zh/django_models/README.md
+++ b/zh/django_models/README.md
@@ -109,7 +109,7 @@ Django 里的模型是一种特殊的对象 — — 它保存在 `数据库` 中
     
     
     class Post(models.Model):
-        author = models.ForeignKey('auth.User')
+        author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
         title = models.CharField(max_length=200)
         text = models.TextField()
         created_date = models.DateTimeField(


### PR DESCRIPTION
Django 1.11 shows a deprecation warning and Django 2.0 will give an error if on_delete is not specified on a ForeignKey.

This includes https://github.com/DjangoGirls/tutorial/pull/1212 and makes all languages consistent.