### PR TITLE
Inline code use oneline code blocks

### DIFF
--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -941,7 +941,7 @@ We want to greet all of them by their name. We have the `hi` function to do that
 for name in girls:
 ```
 
-The ```for``` statement behaves similarly to the ```if``` statement; code below both of these need to be indented four spaces.
+The `for` statement behaves similarly to the `if` statement; code below both of these need to be indented four spaces.
 
 Here is the full code that will be in the file:
 


### PR DESCRIPTION
This change fix translation/Crowdin issue.

When we use \`\`\` inside sentence as an inline code Crowdin divide it to 3 separate sentences for translation (in example below we have 2 occurance of \`\`\` so sentence was divided into 5 pieces):
![bez nazwy](https://user-images.githubusercontent.com/1165138/36441386-c5fae38e-1672-11e8-952b-11352d143930.png)

Such situation is dificult for translator, as there's not so much option to switch syntax inside this "sentences".