### PR TITLE
Crowdin support fix for spanning one XPath into multiple translatable instances

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -82,7 +82,7 @@ $ git commit -m "My Django Girls app, first commit"
  create mode 100644 .gitignore
  [...]
  create mode 100644 mysite/wsgi.py
- ```
+```
 
 
 ## Pushing your code to GitHub


### PR DESCRIPTION
This changes should fix an issue that occurs in Crowdin. Because of this space multiline code block is wronlgy parsed and span from https://crowdin.com/translate/django-girls-tutorial/296/en-pl#8808 up to https://crowdin.com/translate/django-girls-tutorial/296/en-pl#8816

Whole selection on screenshot is composed by one XPath selector - `/pre[4]/code`, I spoke with Crowdin support and they suggest, that this change will fix it.
![multiple-parts-xpath](https://user-images.githubusercontent.com/1165138/36469656-447e50a4-16e8-11e8-8ef6-02d924550c4f.png)
