### PR TITLE
Omit the step number in windows git installation wizard

### DIFF
--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -5,7 +5,7 @@ Git is a "version control system" used by a lot of programmers. This software ca
 <!--sec data-title="Installing Git: Windows" data-id="git_install_windows"
 data-collapse=true ces-->
 
-You can download Git from [git-scm.com](https://git-scm.com/). You can hit "next" on all steps except for one; in the fifth step entitled "Adjusting your PATH environment", choose "Use Git and optional Unix tools from the Windows Command Prompt" (the bottom option). Other than that, the defaults are fine. Checkout Windows-style, commit Unix-style line endings is good.
+You can download Git from [git-scm.com](https://git-scm.com/). You can hit "next" on all steps except for one; in the step entitled "Adjusting your PATH environment", choose "Use Git and optional Unix tools from the Windows Command Prompt" (the bottom option). Other than that, the defaults are fine. Checkout Windows-style, commit Unix-style line endings is good.
 
 Do not forget to restart the command prompt or powershell after the installation finished successfully.
 <!--endsec-->


### PR DESCRIPTION
The step name is sufficient, and more future-proof to changes.

This addresses part of #1224