### PR TITLE
switch from apt-get command to apt

### DIFF
--- a/cs/deploy/install_git.md
+++ b/cs/deploy/install_git.md
@@ -11,7 +11,7 @@ Stáhni Git z [git-scm.com](https://git-scm.com/) a postupuj podle pokynů.
 Pokud ho již nemáš nainstalovaný, git měl by být k dispozici pomocí Správce balíčků, zkus:
 
 ```
-sudo apt-get install git
+sudo apt install git
 # or
 sudo yum install git
 # or

--- a/cs/django_installation/instructions.md
+++ b/cs/django_installation/instructions.md
@@ -50,7 +50,7 @@ Vytvoření `virtualenv` na Linux a OS X je stejně jednoduché - spusť`python3
 >
 > Chceš-li se tomuto vyhnout, použij tento příkaz `virtualenv`.
 >
->     ~/djangogirls$ sudo apt-get install python-virtualenv
+>     ~/djangogirls$ sudo apt install python-virtualenv
 >     ~/djangogirls$ virtualenv --python=python3.4 myvenv
 >     
 

--- a/cs/python_installation/instructions.md
+++ b/cs/python_installation/instructions.md
@@ -26,7 +26,7 @@ Pokud Python nemáš nainstalovaný nebo pokud chceš nainstalovat jinou verzi, 
 Použij tento příkaz v konzoli:
 
 ```
-sudo apt-get install python3.4
+sudo apt install python3.4
 ```
 
 #### Fedora

--- a/de/deploy/install_git.md
+++ b/de/deploy/install_git.md
@@ -11,7 +11,7 @@ Git von [git-scm.com](http://git-scm.com/) herunterladen und dann den Anweisunge
 Falls es noch nicht installiert sein sollte, sollte git als Paket im Paketmanager enthalten sein. Versuche je nach Distribution:
 
 ```bash
-sudo apt-get install git
+sudo apt install git
 ```
     # oder
 ```bash

--- a/de/django_installation/instructions.md
+++ b/de/django_installation/instructions.md
@@ -58,7 +58,7 @@ Eine `virtualenv` auf Linux oder macOS X anzulegen, heißt lediglich `python3 -m
 > 
 > Das zu umgehen, kannst du den `virtualenv`-Befehl verwenden.
 >```bash
->~/djangogirls$ sudo apt-get install python-virtualenv
+>~/djangogirls$ sudo apt install python-virtualenv
 >~/djangogirls$ virtualenv --python=python3.4 myvenv
 >```
 

--- a/de/python_installation/instructions.md
+++ b/de/python_installation/instructions.md
@@ -48,7 +48,7 @@ Wenn Python bei dir nicht installiert ist, oder du eine andere Version willst, k
 Gib diesen Befehl in die Konsole ein:
 
 ```bash
-$ sudo apt-get install python3.5
+$ sudo apt install python3.5
 ```
 
 #### Fedora (bis zu 21)

--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -24,7 +24,7 @@ data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```bash
-$ sudo apt-get install git
+$ sudo apt install git
 ```
 
 <!--endsec-->

--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -63,14 +63,14 @@ $ python3 -m venv myvenv
 >{% filename %}command-line{% endfilename %}
 >```
 >The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package using the following command.
->    apt-get install python3-venv
+>    apt install python3-venv
 >You may need to use sudo with that command.  After installing the python3-venv package, recreate your virtual environment.
 >```
 >
 > In this case, follow the instructions above and install the `python3-venv` package:
 >{% filename %}command-line{% endfilename %}
 >```
->$ sudo apt-get install python3-venv
+>$ sudo apt install python3-venv
 >```
 
 > __NOTE:__ On some versions of Debian/Ubuntu initiating the virtual environment like this currently gives the following error:
@@ -84,7 +84,7 @@ $ python3 -m venv myvenv
 
 >{% filename %}command-line{% endfilename %}
 >```
->$ sudo apt-get install python-virtualenv
+>$ sudo apt install python-virtualenv
 >$ virtualenv --python=python3.6 myvenv
 >```
 

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -61,7 +61,7 @@ Type this command into your console:
 
 {% filename %}command-line{% endfilename %}
 ```
-$ sudo apt-get install python3.6
+$ sudo apt install python3.6
 ```
 
 <!--endsec-->

--- a/es/deploy/README.md
+++ b/es/deploy/README.md
@@ -34,7 +34,7 @@ Descarga Git de [git-scm.com][3] y sigue las instrucciones.
 
 Si no lo tienes ya instalado, git debería estar disponible a través del administrador de paquetes, prueba con:
 
-    sudo apt-get install git
+    sudo apt install git
     # o
     sudo yum install git
     

--- a/es/django_installation/README.md
+++ b/es/django_installation/README.md
@@ -50,7 +50,7 @@ Crear un `virtualenv` en Linux y OS X es tan simple como ejecutar `python3 -m ve
 > 
 > Para evitar esto, utiliza directamente el comando `virtualenv`.
 > 
->     ~/djangogirls$ sudo apt-get install python-virtualenv
+>     ~/djangogirls$ sudo apt install python-virtualenv
 >     ~/djangogirls$ virtualenv --python=python3.4 myvenv
 >     
 

--- a/es/python_installation/README.md
+++ b/es/python_installation/README.md
@@ -36,7 +36,7 @@ Si no tienes Python instalado o si quieres una versión diferente, puedes instal
 
 Tipea este comando en tu consola:
 
-    sudo apt-get install python3.4
+    sudo apt install python3.4
     
 
 #### Fedora

--- a/fr/deploy/install_git.md
+++ b/fr/deploy/install_git.md
@@ -10,7 +10,7 @@ Vous pouvez télécharger Git sur [git-scm.com](https://git-scm.com/). Pour le r
 
 Git est probablement déjà installé mais, si ce n'est pas le cas, voici les instructions à suivre :
 
-    sudo apt-get install git
+    sudo apt install git
      # ou
     sudo yum install git
      # ou

--- a/fr/django_installation/instructions.md
+++ b/fr/django_installation/instructions.md
@@ -46,7 +46,7 @@ Pour créer un `virtualenv` sous Linux ou OS X, tapez simplement la commande `py
 >
 > Pour résoudre ce problème, utilisez plutôt la commande `virtualenv`.
 >
->     ~/djangogirls$ sudo apt-get install python-virtualenv
+>     ~/djangogirls$ sudo apt install python-virtualenv
 >     ~/djangogirls$ virtualenv --python=python3.4 myvenv
 >     
 

--- a/fr/python_installation/instructions.md
+++ b/fr/python_installation/instructions.md
@@ -24,7 +24,7 @@ Si Python n'est pas installé ou que vous avez une version différente, vous pou
 
 Tapez cette commande dans votre terminal :
 
-    $ sudo apt-get install python3.4
+    $ sudo apt install python3.4
     
 
 #### Fedora

--- a/hu/deploy/install_git.md
+++ b/hu/deploy/install_git.md
@@ -23,7 +23,7 @@ data-collapse=true ces-->
 
 {% filename %}parancssor{% endfilename %}
 ```bash
-$ sudo apt-get install git
+$ sudo apt install git
 ```
 
 <!--endsec-->

--- a/hu/django_installation/instructions.md
+++ b/hu/django_installation/instructions.md
@@ -50,14 +50,14 @@ A `myvenv` a`virtualenv`-ed neve. Más nevet is használhatsz, de maradj a kisbe
 >{% filename %}parancssor{% endfilename %}
 >```
 >The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package using the following command.
->    apt-get install python3-venv
+>    apt install python3-venv
 >You may need to use sudo with that command.  After installing the python3-venv package, recreate your virtual environment.
 >```
 >
 > Ebben az esetben a fenti leírást követve telepítsd a `python3-venv` csomagot:
 >{% filename %}parancssor{% endfilename %}
 >```
->$ sudo apt-get install python3-venv
+>$ sudo apt install python3-venv
 >```
 
 > **MEGJEGYZÉS:** A virtuális környezetet létrehozó parancs Ubuntu 14.04 alatt ezt a hibát adja:
@@ -67,7 +67,7 @@ A `myvenv` a`virtualenv`-ed neve. Más nevet is használhatsz, de maradj a kisbe
 > 
 > Hogy ezt elkerüld, használd a `virtualenv` parancsot.
 > 
->     ~/djangogirls$ sudo apt-get install python-virtualenv
+>     ~/djangogirls$ sudo apt install python-virtualenv
 >     ~/djangogirls$ virtualenv --python=python3.6 myvenv
 >     
 

--- a/hu/python_installation/instructions.md
+++ b/hu/python_installation/instructions.md
@@ -42,7 +42,7 @@ data-collapse=true ces-->
 
 Írd be az alábbi parancsot a konzolba:
 
-    $ sudo apt-get install python3.4
+    $ sudo apt install python3.4
     
 <!--endsec-->
 

--- a/it/deploy/install_git.md
+++ b/it/deploy/install_git.md
@@ -10,7 +10,7 @@ Scarica Git da [git-scm.com](https://git-scm.com/) e segui le istruzioni.
 
 Se non è già installato, git dovrebbe essere disponibile tramite il gestore di pacchetti, prova a cercare:
 
-    sudo apt-get install git 
+    sudo apt install git 
     # oppure
     sudo yum install git
     # oppure

--- a/it/django_installation/instructions.md
+++ b/it/django_installation/instructions.md
@@ -46,7 +46,7 @@ Creare un `virtualenv` su Linux e OS X è semplice, basta digitare: `python3 -m 
 > 
 > Per aggirare il problema utilizza, invece del precedente, il comando `virtualenv`.
 > 
->     ~/djangogirls$ sudo apt-get install python-virtualenv
+>     ~/djangogirls$ sudo apt install python-virtualenv
 >     ~/djangogirls$ virtualenv --python=python3.4 myvenv
 >     
 

--- a/it/python_installation/instructions.md
+++ b/it/python_installation/instructions.md
@@ -24,7 +24,7 @@ Se non hai Python installato o se vuoi una versione diversa, puoi installarla co
 
 Digita questo comando nella tua console:
 
-    $ sudo apt-get install python3.4
+    $ sudo apt install python3.4
     
 
 #### Fedora

--- a/ko/deploy/install_git.md
+++ b/ko/deploy/install_git.md
@@ -24,7 +24,7 @@ data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```bash
-$ sudo apt-get install git
+$ sudo apt install git
 ```
 
 <!--endsec-->

--- a/ko/django_installation/instructions.md
+++ b/ko/django_installation/instructions.md
@@ -55,14 +55,14 @@ $ python3 -m venv myvenv
 {% filename %}command-line{% endfilename %}
 ```
 The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package using the following command.
-    apt-get install python3-venv
+    apt install python3-venv
 You may need to use sudo with that command.  After installing the python3-venv package, recreate your virtual environment.
 ```
 
 이 경우, 위의 지시에 따라 `python3-venv` 패키지를 설치하세요. :
 {% filename %}command-line{% endfilename %}
 ```
-$ sudo apt-get install python3-venv
+$ sudo apt install python3-venv
 ```
 
 > **Note** Debian/Ubuntu의 일부 버전에서 이와 같이 가상 환경을 초기화하면 현재 다음과 같은 오류가 발생합니다. :
@@ -75,7 +75,7 @@ Error: Command '['/home/eddie/Slask/tmp/venv/bin/python3', '-Im', 'ensurepip', '
 
 {% filename %}command-line{% endfilename %}
 ```
-$ sudo apt-get install python-virtualenv
+$ sudo apt install python-virtualenv
 $ virtualenv --python=python3.6 myvenv
 ```
 

--- a/ko/python_installation/instructions.md
+++ b/ko/python_installation/instructions.md
@@ -64,7 +64,7 @@ data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
-$ sudo apt-get install python3.6
+$ sudo apt install python3.6
 ```
 
 <!--endsec-->

--- a/pl/deploy/install_git.md
+++ b/pl/deploy/install_git.md
@@ -24,7 +24,7 @@ data-collapse=true ces-->
 {% filename %}command-line{% endfilename %}
 
 ```bash
-$ sudo apt-get install git
+$ sudo apt install git
 ```
 
 <!--endsec-->

--- a/pl/django_installation/instructions.md
+++ b/pl/django_installation/instructions.md
@@ -58,13 +58,13 @@ Możemy stworzyć `virtualenv`'a w Linuksie i OS X poprzez użycie jedynie polec
 > {% filename %}command-line{% endfilename %}
 > 
 >     The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package using the following command.
->        apt-get install python3-venv
+>        apt install python3-venv
 >     You may need to use sudo with that command.  After installing the python3-venv package, recreate your virtual environment.
 >     
 > 
 > W tym przypadku, wykonaj powyższe instrukcje i zainstaluj pakiet `python3-venv`: {% filename %}command-line{% endfilename %}
 > 
->     $ sudo apt-get install python3-venv
+>     $ sudo apt install python3-venv
 >     
 > 
 > **UWAGA:** W niektórych wersjach Debiana/Ubuntu inicjowanie środowiska wirtualnego w ten sposób daje obecnie następujący błąd:
@@ -78,7 +78,7 @@ Możemy stworzyć `virtualenv`'a w Linuksie i OS X poprzez użycie jedynie polec
 > 
 > {% filename %}command-line{% endfilename %}
 > 
->     $ sudo apt-get install python-virtualenv
+>     $ sudo apt install python-virtualenv
 >     $ virtualenv --python=python3.6 myvenv
 >     
 > 

--- a/pl/python_installation/instructions.md
+++ b/pl/python_installation/instructions.md
@@ -60,7 +60,7 @@ Wpisz w konsoli poniższe polecenie:
 
 {% filename %}command-line{% endfilename %}
 
-    $ sudo apt-get install python3.6
+    $ sudo apt install python3.6
     
 
 <!--endsec-->

--- a/pt/deploy/install_git.md
+++ b/pt/deploy/install_git.md
@@ -29,7 +29,7 @@ data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```bash
-$ sudo apt-get install git
+$ sudo apt install git
 ```
 
 <!--endsec-->

--- a/pt/django_installation/instructions.md
+++ b/pt/django_installation/instructions.md
@@ -58,14 +58,14 @@ $ python3 -m venv myvenv
 > {% filename %}command-line{% endfilename %}
 >```
 > The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package using the following command.
->    apt-get install python3-venv
+>    apt install python3-venv
 > You may need to use sudo with that command.  After installing the python3-venv package, recreate your virtual environment.
 >```
 >
 > Nesse caso, siga as instruções acima e instale o pacote `python3-venv`:
 >{% filename %}command-line{% endfilename %}
 >```
->$ sudo apt-get install python3-venv
+>$ sudo apt install python3-venv
 >```
 
 > __NOTA:__ Em algumas versões do Debian/Ubuntu inicializar o ambiente virtual dessa forma retorna o seguinte erro:
@@ -79,7 +79,7 @@ $ python3 -m venv myvenv
 
 >{% filename %}command-line{% endfilename %}
 >```
->$ sudo apt-get install python-virtualenv
+>$ sudo apt install python-virtualenv
 >$ virtualenv --python=python3.5 myvenv
 >```
 

--- a/pt/python_installation/instructions.md
+++ b/pt/python_installation/instructions.md
@@ -63,7 +63,7 @@ Use esse comando em seu console:
 
 {% filename %}command-line{% endfilename %}
 ```
-$ sudo apt-get install python3.5
+$ sudo apt install python3.5
 ```
 
 <!--endsec-->

--- a/ru/deploy/install_git.md
+++ b/ru/deploy/install_git.md
@@ -24,7 +24,7 @@ data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```bash
-$ sudo apt-get install git
+$ sudo apt install git
 ```
 
 <!--endsec-->

--- a/ru/django_installation/instructions.md
+++ b/ru/django_installation/instructions.md
@@ -58,14 +58,14 @@ $ python3 -m venv myvenv
 >{% filename %}command-line{% endfilename %}
 >```
 >The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package using the following command.
->    apt-get install python3-venv
+>    apt install python3-venv
 >You may need to use sudo with that command.  After installing the python3-venv package, recreate your virtual environment.
 >```
 >
 > В таком случае следуй приведённым инструкциям и установи пакет `python3-venv`:
 >{% filename %}command-line{% endfilename %}
 >```
->$ sudo apt-get install python3-venv
+>$ sudo apt install python3-venv
 >```
 
 > __Примечание:__ В некоторых версиях of Debian/Ubuntu при таком способе создания виртуального окружения ты можешь получить такую ошибку:
@@ -79,7 +79,7 @@ $ python3 -m venv myvenv
 
 >{% filename %}command-line{% endfilename %}
 >```
->$ sudo apt-get install python-virtualenv
+>$ sudo apt install python-virtualenv
 >$ virtualenv --python=python3.6 myvenv
 >```
 

--- a/ru/python_installation/instructions.md
+++ b/ru/python_installation/instructions.md
@@ -62,7 +62,7 @@ data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
-$ sudo apt-get install python3.6
+$ sudo apt install python3.6
 ```
 
 <!--endsec-->

--- a/sk/deploy/install_git.md
+++ b/sk/deploy/install_git.md
@@ -24,7 +24,7 @@ data-collapse=true ces-->
 {% filename %}command-line{% endfilename %}
 
 ```bash
-$ sudo apt-get install git
+$ sudo apt install git
 ```
 
 <!--endsec-->

--- a/sk/django_installation/instructions.md
+++ b/sk/django_installation/instructions.md
@@ -58,13 +58,13 @@ Vytvoriť `virtualenv` na Linuxe a OS X vyžaduje iba jednoduché spustenie `pyt
 > {% filename %}command-line{% endfilename %}
 > 
 >     The virtual environment was not created successfully because ensurepip is not available.  On Debian/Ubuntu systems, you need to install the python3-venv package using the following command.
->        apt-get install python3-venv
+>        apt install python3-venv
 >     You may need to use sudo with that command.  After installing the python3-venv package, recreate your virtual environment.
 >     
 > 
 > V tomto prípade postupuj podľa pokynov uvedených vyššie a nainštaluj si balík `python3-venv`: {% filename %}command-line{% endfilename %}
 > 
->     $ sudo apt-get install python3-venv
+>     $ sudo apt install python3-venv
 >     
 > 
 > **POZNÁMKA:** V niektorých verziách Debian/Ubuntu inicializovanie virtuálneho prostredia týmto spôsobom vráti nasledovnú chybu:
@@ -78,7 +78,7 @@ Vytvoriť `virtualenv` na Linuxe a OS X vyžaduje iba jednoduché spustenie `pyt
 > 
 > {% filename %}command-line{% endfilename %}
 > 
->     $ sudo apt-get install python-virtualenv
+>     $ sudo apt install python-virtualenv
 >     $ virtualenv --python=python3.6 myvenv
 >     
 > 

--- a/sk/python_installation/instructions.md
+++ b/sk/python_installation/instructions.md
@@ -60,7 +60,7 @@ Zadaj do konzoly tento príkaz:
 
 {% filename %}command-line{% endfilename %}
 
-    $ sudo apt-get install python3.6
+    $ sudo apt install python3.6
     
 
 <!--endsec-->

--- a/tr/deploy/install_git.md
+++ b/tr/deploy/install_git.md
@@ -24,7 +24,7 @@ data-collapse=true ces-->
 {% filename %}komut-satırı{% endfilename %}
 
 ```bash
-$ sudo apt-get install git
+$ sudo apt install git
 ```
 
 <!--endsec-->

--- a/tr/django_installation/instructions.md
+++ b/tr/django_installation/instructions.md
@@ -58,13 +58,13 @@ Burada `myvenv` sizin `virtualenv`'inizin ismi. Dilerseniz istediğiniz herhangi
 > {% filename %}komut-satırı{% endfilename %}
 > 
 >     The virtual environment was not created successfully because ensurepip is not available.  Debian/Ubuntu sistemlerinde, python3-venv paketini aşağıdaki komutu kullanarak yüklemeniz gerekiyor.
->        apt-get install python3-venv
+>        apt install python3-venv
 >     You may need to use sudo with that command.  After installing the python3-venv package, recreate your virtual environment.
 >     
 > 
 > Bu durumda,yukarıdaki yönergeleri izleyin ve `python3-venv` paketini yükleyin:
 > 
->     $ sudo apt-get install python3-venv
+>     $ sudo apt install python3-venv
 >     
 > 
 > Bu Şekilde Debian/Ubuntu ' nun bazı sürümlerinde sanal ortamı başlatırken o anda aşağıdaki hatayı alabilirsiniz : 
@@ -78,7 +78,7 @@ Burada `myvenv` sizin `virtualenv`'inizin ismi. Dilerseniz istediğiniz herhangi
 > 
 > {% filename %}komut-satırı{% endfilename %}
 > 
->     $ sudo apt-get install python-virtualenv
+>     $ sudo apt install python-virtualenv
 >     $ virtualenv --python=python3.6 myvenv
 >     
 > 

--- a/tr/python_installation/instructions.md
+++ b/tr/python_installation/instructions.md
@@ -60,7 +60,7 @@ Terminale bu komutu girin:
 
 {% filename %}komut satırı{% endfilename %}
 
-    $ sudo apt-get install python3.6
+    $ sudo apt install python3.6
     
 
 <!--endsec-->

--- a/uk/deploy/install_git.md
+++ b/uk/deploy/install_git.md
@@ -15,7 +15,7 @@ Git можна завантажити з [git-scm.com](https://git-scm.com/). В
 
 #### Debian або Ubuntu
 
-    $ sudo apt-get install git
+    $ sudo apt install git
 
 
 #### Fedora

--- a/uk/django_installation/instructions.md
+++ b/uk/django_installation/instructions.md
@@ -46,7 +46,7 @@
 
 > Щоб обійти цю проблему, використовуйте натомість команду `virtualenv`.
 
->     $ sudo apt-get install python-virtualenv
+>     $ sudo apt install python-virtualenv
 >     $ virtualenv --python=python3.4 myvenv
 
 

--- a/uk/python_installation/instructions.md
+++ b/uk/python_installation/instructions.md
@@ -26,7 +26,7 @@ Python для Windows можна завантажити з сайту https://ww
 
 Наберіть наступну команду в консолі:
 
-    $ sudo apt-get install python3.4
+    $ sudo apt install python3.4
 
 
 #### Fedora

--- a/zh/deploy/install_git.md
+++ b/zh/deploy/install_git.md
@@ -10,7 +10,7 @@
 
 如果git还没有被安装的话，你可以从你的软件包管理器中下载git, 请试试下面命令:
 
-    sudo apt-get install git
+    sudo apt install git
     # or
     sudo yum install git
     # or

--- a/zh/django_installation/instructions.md
+++ b/zh/django_installation/instructions.md
@@ -46,7 +46,7 @@
 > 
 > 为了解决这个问题，请使用 `virtualenv` 命令。
 > 
->     ~/djangogirls$ sudo apt-get install python-virtualenv
+>     ~/djangogirls$ sudo apt install python-virtualenv
 >     ~/djangogirls$ virtualenv --python=python3.4 myvenv
 >     
 

--- a/zh/python_installation/instructions.md
+++ b/zh/python_installation/instructions.md
@@ -24,7 +24,7 @@ Django 是用 Python 写的。 在 Django 中，我们需要使用 Python 语言
 
 在控制台中键入此命令：
 
-    $ sudo apt-get install python3.4
+    $ sudo apt install python3.4
     
 
 #### Fedora


### PR DESCRIPTION
How about changing apt-get to apt. Given that fedora uses one three letter command for installation it looks better.
It's included in Ubuntu since 14.04 and in Debian since Jessie.
