### PR TITLE
gitignore - ignore *.swp and .idea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ MANIFEST
 .DS_Store
 _book
 node_modules
+.idea
+.swp


### PR DESCRIPTION
Ignore VIM's temporary files `*.swp` and JetBrains's `.idea`