### PR TITLE
Update Cloud9 instructions

### DIFF
--- a/en/chromebook_setup/instructions.md
+++ b/en/chromebook_setup/instructions.md
@@ -11,12 +11,22 @@ running commands in a terminal interface just like your classmates on OS X,
 Ubuntu, or Windows, but your terminal will be connected to a computer running
 somewhere else that Cloud 9 sets up for you.
 
+Currently Cloud 9 requires you to sign up with AWS and enter credit card
+information.
+
 1. Install Cloud 9 from the [Chrome web store](https://chrome.google.com/webstore/detail/cloud9/nbdmccoknlfggadpfkmcpnamfnbkmkcp)
-2. Go to [c9.io](https://c9.io)
-3. Sign up for an account
-4. Click _Create a New Workspace_
-5. Name it _django-girls_
-6. Select the _Blank_ (second from the right on the bottom row with orange logo)
+2. Go to [c9.io](https://c9.io) and click _Get started with AWS Cloud9_
+3. Sign up for an AWS account (requires credit card information, but you can
+   use it for free)
+4. In the AWS Dashboard, enter _Cloud9_ in the search bar and click it
+5. In the Cloud 9 dashboard, click _Create environment_
+6. Name it _django-girls_
+7. While configuring settings, select _Create a new instance for environment
+   (EC2)_ for "Environment Type" and the _t2.micro_ "Instance type" (it should
+   say "Free-tier eligible."). The default cost-saving setting is fine and you
+   can keep the other defaults.
+8. Click _Next step_
+9. Click _Create environment_
 
 Now you should see an interface with a sidebar, a big main window with some
 text, and a small window at the bottom that looks something like this:
@@ -37,17 +47,7 @@ stuff useful computer code into for a project we're working on. We use them to
 keep the various bits of code we want for our various projects separate so
 things don't get mixed up between projects.
 
-In your terminal at the bottom of the Cloud 9 interface, run the following:
-
-{% filename %}Cloud 9{% endfilename %}
-```
-sudo apt update
-sudo apt install python3.6-venv
-```
-
-If this still doesn't work, ask your coach for some help.
-
-Next, run:
+Run:
 
 {% filename %}Cloud 9{% endfilename %}
 ```


### PR DESCRIPTION
Changes in this pull request:

- Update the AWS/Cloud9 account creation documentation
- Mentioned the need for credit card
- Updated the Environment Creation documentation

Until a decision is made in #1081, this should make setting up Cloud9 less confusing :-)