### PR TITLE
Correct cd command on updating the deployment

### DIFF
--- a/en/django_templates/README.md
+++ b/en/django_templates/README.md
@@ -89,7 +89,7 @@ $ git push
 
 {% filename %}PythonAnywhere command-line{% endfilename %}
 ```
-$ cd my-first-blog
+$ cd $USER.pythonanywhere.com
 $ git pull
 [...]
 ```


### PR DESCRIPTION
Previously we cloned to my-first-blog but the current script deploys to
$USER.pythonanywhere.com. This corrects the step so students aren't
confused.

Fixes #1267