### PR TITLE
Move note about searching for "Command Prompt" to start-menu-based instructions

### DIFF
--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -13,7 +13,7 @@ One thing to watch out for: During the installation, you will notice a window ma
 
 ![Don't forget to add Python to the Path](../python_installation/images/python-installation-options.png)
 
-In upcoming steps, you'll be using the Windows Command Line (which we'll also tell you about). For now, if you need to type in some commands, go to Start menu → Windows System → Command Prompt. (On newer versions of Windows, you might have to search for "Command Prompt" since it's sometimes hidden.) You can also hold in the Windows key and press the "R"-key until the "Run" window pops up. To open the Command Line, type "cmd" and press enter in the "Run" window.
+In upcoming steps, you'll be using the Windows Command Line (which we'll also tell you about). For now, if you need to type in some commands, go to Start menu and enter "Command Prompt" into the search field there. (On older versions of Windows, you can start the Command Line with Start menu → Windows System → Command Prompt.) You can also hold in the Windows key and press the "R"-key until the "Run" window pops up. To open the Command Line, type "cmd" and press enter in the "Run" window.
 
 ![Type "cmd" in the "Run" window](../python_installation/images/windows-plus-r.png)
 

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -13,7 +13,7 @@ One thing to watch out for: During the installation, you will notice a window ma
 
 ![Don't forget to add Python to the Path](../python_installation/images/python-installation-options.png)
 
-In upcoming steps, you'll be using the Windows Command Line (which we'll also tell you about). For now, if you need to type in some commands, go to Start menu → Windows System → Command Prompt. You can also hold in the Windows key and press the "R"-key until the "Run" window pops up. To open the Command Line, type "cmd" and press enter in the "Run" window. (On newer versions of Windows, you might have to search for "Command Prompt" since it's sometimes hidden.)
+In upcoming steps, you'll be using the Windows Command Line (which we'll also tell you about). For now, if you need to type in some commands, go to Start menu → Windows System → Command Prompt. (On newer versions of Windows, you might have to search for "Command Prompt" since it's sometimes hidden.) You can also hold in the Windows key and press the "R"-key until the "Run" window pops up. To open the Command Line, type "cmd" and press enter in the "Run" window.
 
 ![Type "cmd" in the "Run" window](../python_installation/images/windows-plus-r.png)
 


### PR DESCRIPTION
Move note about searching for "Command Prompt" to between the instructions for getting it from the start menu and the Win-R "cmd"-instructions, as the searching probably refers to within the start menu (which is searchable in newer Windows versions and might offer some entries only through search).