### PR TITLE
Add missing PythonAnywhere command description

### DIFF
--- a/en/html/README.md
+++ b/en/html/README.md
@@ -197,7 +197,7 @@ $ git push
 
 * Open up the [PythonAnywhere consoles page](https://www.pythonanywhere.com/consoles/) and go to your **Bash console** (or start a new one). Then, run:
 
-{% filename %}command-line{% endfilename %}
+{% filename %}PythonAnywhere command-line{% endfilename %}
 ```
 $ cd ~/<your-pythonanywhere-username>.pythonanywhere.com
 $ git pull

--- a/pl/html/README.md
+++ b/pl/html/README.md
@@ -199,7 +199,7 @@ Jak już wszystko to zrobimy, możemy wysłać (push) nasze zmiany na Githuba:
 
 * Otwórz [stronę konsoli na PythonAnywhere](https://www.pythonanywhere.com/consoles/) i przejdź do swojej **Bash console** (czyli po polsku "konsoli Bash") albo otwórz nową. Wpisz do niej:
 
-{% filename %}command-line{% endfilename %}
+{% filename %}PythonAnywhere command-line{% endfilename %}
 
     $ cd ~/<your-pythonanywhere-username>.pythonanywhere.com
     $ git pull


### PR DESCRIPTION
Changes in this pull request:

One of the command blocks incorrectly specified target console. It should be PythonAnywhere not local one.
