### PR TITLE
Replace {% load staticfiles %} with {% load static %}

### DIFF
--- a/de/css/README.md
+++ b/de/css/README.md
@@ -89,7 +89,7 @@ In einer CSS-Datei werden Stile für Elemente der HTML-Datei festgelegt. Die Ele
 Dann musst du auch deiner HTML-Vorlage sagen, dass wir CSS aus einer externen Datei laden wollen. Öffne dazu die Datei `blog/templates/blog/post_list.html` und füge folgende Zeile ganz am Anfang der Datei an:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 ```
 
 Hier laden wir nur statische Dateien :). Dann fügst du zwischen `<head>` und `</head>`, nach dem Link auf die Bootstrap-CSS-Dateien die folgenden Zeilen an (Der Browser liest die Dateien in der Reihenfolge, wie sie angegeben sind, ein, so dass dein CSS möglicherweise den Code in den Bootstrap-Dateien überschreibt.):
@@ -103,7 +103,7 @@ Wir haben unserer Vorlage gerade gesagt, wo sich die CSS-Datei befindet.
 Deine Datei sollte jetzt so aussehen:
 
 ```html 
-{% load staticfiles %} 
+{% load static %} 
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/de/django_forms/README.md
+++ b/de/django_forms/README.md
@@ -54,7 +54,7 @@ Merk dir, dass wir unseren neuen View `post_new` nennen wollen.
 Nach Hinzufügen der Zeile sieht deine HTML-Datei so aus:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/de/template_extending/README.md
+++ b/de/template_extending/README.md
@@ -21,7 +21,7 @@ blog
 Öffne sie, kopiere alles von `post_list.html` und füge es wie folgt in die `base.html`-Datei ein:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/en/css/README.md
+++ b/en/css/README.md
@@ -97,7 +97,7 @@ We also need to tell our HTML template that we added some CSS. Open the `blog/te
 
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 ```
 
 We're just loading static files here. :)
@@ -114,7 +114,7 @@ Your file should now look like this:
 
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -57,7 +57,7 @@ After adding the line, your HTML file should now look like this:
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/en/template_extending/README.md
+++ b/en/template_extending/README.md
@@ -22,7 +22,7 @@ Then open it up and copy everything from `post_list.html` to `base.html` file, l
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/fr/css/README.md
+++ b/fr/css/README.md
@@ -95,7 +95,7 @@ Nous vous conseillons d'en apprendre un peu plus sur les sélecteurs CSS sur [w3
 Afin que nos modifications fonctionnent, nous devons aussi signaler à notre template HTML que nous utilisons des CSS. Ouvrez le fichier `blog/templates/blog/post_list.html` et ajoutez cette ligne au tout début de celui-ci :
 
 ```html
-{% load staticfiles %}
+{% load static %}
 ```
 
 Hop, nous chargeons les fichiers statiques :). Pour l'ajout de code suivant, gardez en tête que le navigateur lit vos fichiers dans l'ordre dans lequel ils lui sont donnés : en le plaçant à l'endroit que nous vous indiquons, vous allez pouvoir remplacer du code provenant des fichiers Boostrap par le vôtre. Donc, entre le `<head>` et le `</head>` et après les liens vers les fichiers CSS de Boostrap, ajoutez ceci :
@@ -109,7 +109,7 @@ Nous venons simplement de dire à notre template où nous avons rangé notre fic
 Maintenant, votre fichier doit ressembler à ceci :
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/fr/django_forms/README.md
+++ b/fr/django_forms/README.md
@@ -53,7 +53,7 @@ Remarquez que notre nouvelle vue s'appelle `post_new`.
 Après avoir ajouté cette ligne, votre fichier html devrait maintenant ressembler à ceci :
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/fr/template_extending/README.md
+++ b/fr/template_extending/README.md
@@ -20,7 +20,7 @@ Créons le fichier `base.html` dans le dossier `blog/templates/blog/` :
 Ensuite, ouvrez ce fichier `base.html` et collez-y tout ce qui se trouve dans le fichier `post_list.html`. Ça devrait ressembler à ça :
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/hu/css/README.md
+++ b/hu/css/README.md
@@ -93,7 +93,7 @@ Olvass utána a [CSS szelektorokról a w3schools oldalán][4].
 Mindezek után közölnünk kell a HTML fájlunkkal is, hogy hozzáadtunk pár CSS-t. Nyisd meg a `blog/templates/blog/post_list.html` fájlt és add a következő sort a fájl legelejére:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 ```    
 
 Itt csak betöltünk pár statikus fájlt :). Ezután a `<head>` és a `</head>` tagek közé, a Bootstrap CSS fájlok linkjei után (a böngésző olyan sorrendben olvassa az egyes fájlokat, amilyenben követik egymást, tehát a mi fájlunkban lévő kód lehet, hogy felülír pár kódot a Bootstrap fájlban), a következő sort add:
@@ -107,7 +107,7 @@ Most megmondtuk a template-ünknek, hol találja a CSS fájlokat.
 Így kellene kinéznie a fájlodnak:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/hu/django_forms/README.md
+++ b/hu/django_forms/README.md
@@ -53,7 +53,7 @@ Figyelem: az új nézetünket `post_new`-nak fogjuk hívni. A `"glyphicon glyphi
 Miután hozzáadtad ezt a sort, így fog kinézni a html fájlod:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/hu/template_extending/README.md
+++ b/hu/template_extending/README.md
@@ -20,7 +20,7 @@ Hozz létre egy `base.html` fájlt a `blog/templates/blog/`-ban:
 Majd nyisd meg, és másolj át mindent a `post_list.html`-ből a `base.html`-be, így:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/ko/css/README.md
+++ b/ko/css/README.md
@@ -99,7 +99,7 @@ W3Schools에서 [CSS 선택자](https://www.w3schools.com/cssref/css_selectors.a
 
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 ```
 
 여기에서 동적 파일을 로딩하는 거에요. :)
@@ -117,7 +117,7 @@ W3Schools에서 [CSS 선택자](https://www.w3schools.com/cssref/css_selectors.a
 
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/ko/django_forms/README.md
+++ b/ko/django_forms/README.md
@@ -58,7 +58,7 @@ class PostForm(forms.ModelForm):
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/ko/template_extending/README.md
+++ b/ko/template_extending/README.md
@@ -21,7 +21,7 @@
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/pl/css/README.md
+++ b/pl/css/README.md
@@ -93,7 +93,7 @@ Musimy też powiedzieć naszemu szablonowi HTML, że dodałyśmy trochę styli C
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 ```
 
 Tutaj ładujemy pliki statyczne :) Pomiędzy tagami `<head>` oraz `</head>`, po liniach linkujących do plików CSS Bootstrapa, dodaj tę linię:
@@ -111,7 +111,7 @@ Twój plik powinien teraz wyglądać tak:
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/pl/django_forms/README.md
+++ b/pl/django_forms/README.md
@@ -59,7 +59,7 @@ Po dodaniu powyższej linii Twój plik HTML powinien wyglądać następująco:
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/pl/template_extending/README.md
+++ b/pl/template_extending/README.md
@@ -22,7 +22,7 @@ Następnie otwórz go i skopiuj całą zawartość pliku `post_list.html` do pli
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/ru/css/README.md
+++ b/ru/css/README.md
@@ -99,7 +99,7 @@ h1 a {
 
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 ```
 
 Мы просто загружаем здесь статические файлы :)
@@ -116,7 +116,7 @@ h1 a {
 
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/ru/django_forms/README.md
+++ b/ru/django_forms/README.md
@@ -57,7 +57,7 @@ class PostForm(forms.ModelForm):
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/ru/template_extending/README.md
+++ b/ru/template_extending/README.md
@@ -22,7 +22,7 @@ blog
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/sk/css/README.md
+++ b/sk/css/README.md
@@ -93,7 +93,7 @@ Ešte musíme povedať našej HTML šablóne, že sme pridali nejaké CSS. Otvor
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 ```
 
 Tu sme len nahrali statické súbory. :) Medzi `<head>` a `</head>`, po odkazoch na Bootstrap CSS súbory pridať tento riadok:
@@ -111,7 +111,7 @@ Súbor by mal teraz vyzerať asi takto:
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/sk/django_forms/README.md
+++ b/sk/django_forms/README.md
@@ -59,7 +59,7 @@ Po pridaní riadku by tvoj html súbor mal vyzerať asi takto:
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/sk/template_extending/README.md
+++ b/sk/template_extending/README.md
@@ -22,7 +22,7 @@ Otvor ho a skopíruj doň všetko z `post_list.html` do súboru `base.html`:
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/tr/css/README.md
+++ b/tr/css/README.md
@@ -92,7 +92,7 @@ Bir de HTML şablonuna projemize CSS eklediğimizi bildirmemiz gerekiyor. `blog/
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 ```
 
 Burada sadece statik dosya ekliyoruz :) `<head>` ve `</head>` etiketleri arasına, bootstrap linklerinde sonra, şu satırı ekleyelim:
@@ -110,7 +110,7 @@ Tarayıcı, dosyaları verilen sırada okuyor. O yüzden doğru yerde olduğunda
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/tr/django_forms/README.md
+++ b/tr/django_forms/README.md
@@ -59,7 +59,7 @@ Satırı ekledikten sonra, HTML dosyanız bu şekilde görünmelidir:
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/tr/template_extending/README.md
+++ b/tr/template_extending/README.md
@@ -22,7 +22,7 @@ Sonra bunu açalım ve `post_list.html` dosyasındaki her şeyi aşağıdaki gib
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls Blog</title>

--- a/uk/css/README.md
+++ b/uk/css/README.md
@@ -92,7 +92,7 @@ Class і id - імена, які ви присвоюєте елементам в
 Далі, нам треба повідомити наш HTML-шаблон про те, що ми додали CSS. Відкрийте файл `blog/templates/blog/post_list.html` і додайте на початок цей рядок:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 ```
 
 Тут лише завантажуються статичні файли :)
@@ -107,7 +107,7 @@ Class і id - імена, які ви присвоюєте елементам в
 Тепер ваш файл має виглядати наступним чином:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/uk/django_forms/README.md
+++ b/uk/django_forms/README.md
@@ -52,7 +52,7 @@ class PostForm(forms.ModelForm):
 Після додавання відповідного рядка, ваш html файл має виглядати наступним чином:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>

--- a/uk/template_extending/README.md
+++ b/uk/template_extending/README.md
@@ -19,7 +19,7 @@
 Відкрийте його і скопіюйте усе з `post_list.html` до файлу `base.html`, як тут:
 
 ```html
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <title>Django Girls blog</title>


### PR DESCRIPTION
Changes in this pull request:

- Replace `{% load staticfiles %}` with `{% load static %}`

The usage of `{% load static %}` has been available since [Django 1.10](https://docs.djangoproject.com/en/dev/releases/1.10/#django-contrib-staticfiles).

The usage of `{% load staticfiles %}` has become deprecated in [Django 2.1](https://docs.djangoproject.com/en/dev/releases/2.1/#id2).
