### PR TITLE
Use fork of sectionx plugin to fix arrow direction

### DIFF
--- a/book.json
+++ b/book.json
@@ -16,7 +16,7 @@
         "language-picker",
         "sidebar-ad",
         "codeblock-label",
-        "sectionx"
+        "sectionx-ex"
     ],
     "pluginsConfig": {
         "ga": {


### PR DESCRIPTION
The original sectionx plugin has a [bug][1] that manifests itself in the
Django Girls tutorial. The initial state of the arrow used to expand
operating-system-specific sections is wrong and can cause confusion.

The creator of sectionx has not been responsive in a [Pull Request to fix
the issue][2]. Another user has created a fork which includes the fix
and we can benefit from that.

[1]: https://github.com/ymcatar/gitbook-plugin-sectionx/issues/6
[2]: https://github.com/ymcatar/gitbook-plugin-sectionx/pull/7
