### PR TITLE
Fix for #1305, fix urls.py example missing an import

### DIFF
--- a/en/extend_your_application/README.md
+++ b/en/extend_your_application/README.md
@@ -57,7 +57,7 @@ Let's make a URL in the `blog/urls.py` file to point Django to a *view* named `p
 
 {% filename %}{{ warning_icon }} blog/urls.py{% endfilename %}
 ```python
-from django.conf.urls import url
+from django.urls import path
 from . import views
 
 urlpatterns = [


### PR DESCRIPTION
Changes in this pull request:

- change import sentence in `blog/urls.py`
