### PR TITLE
Install code editor before Django

### DIFF
--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -172,7 +172,7 @@ Before we do that, we should make sure we have the latest version of `pip`, the 
 A requirements file keeps a list of dependencies to be installed using
 `pip install`:
 
-First create a `requirements.txt` file inside of `djangogirls/` folder:
+First create a `requirements.txt` file inside of `djangogirls/` folder, using the code editor that you installed earlier:
 
 ```
 djangogirls

--- a/en/installation/README.md
+++ b/en/installation/README.md
@@ -19,11 +19,11 @@ data-id="chromebook_setup" data-collapse=true ces-->
 # Install Python
 {% include "/python_installation/instructions.md" %}
 
-# Set up virtualenv and install Django
-{% include "/django_installation/instructions.md" %}
-
 # Install a code editor
 {% include "/code_editor/instructions.md" %}
+
+# Set up virtualenv and install Django
+{% include "/django_installation/instructions.md" %}
 
 # Install Git
 {% include "/deploy/install_git.md" %}


### PR DESCRIPTION
Fix for #1306 : On the Installation page, install the code editor before Django  -- it is already in that order in the main flow of the document, but not in the one-page installation guide. Then when installing Django, say to use the code editor to create the requirements.txt file.