### PR TITLE
Remove suggestion to copy the clone URL

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -96,13 +96,13 @@ Then, create a new repository, giving it the name "my-first-blog". Leave the "in
 
 > **Note** The name `my-first-blog` is important – you could choose something else, but it's going to occur lots of times in the instructions below, and you'd have to substitute it each time. It's probably easier to just stick with the name `my-first-blog`.
 
-On the next screen, you'll be shown your repo's clone URL. Choose the "HTTPS" version, copy it, and we'll paste it into the terminal shortly:
+On the next screen, you'll be shown your repo's clone URL, which you will use in some of the commands that follow:
 
 <img src="images/github_get_repo_url_screenshot.png" />
 
 Now we need to hook up the Git repository on your computer to the one up on GitHub.
 
-Type the following into your console (Replace `<your-github-username>` with the username you entered when you created your GitHub account, but without the angle-brackets):
+Type the following into your console (replace `<your-github-username>` with the username you entered when you created your GitHub account, but without the angle-brackets -- the URL should match the clone URL you just saw):
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -155,7 +155,7 @@ $ pip3.6 install --user pythonanywhere
 
 That should print out some things like `Collecting pythonanywhere`, and eventually end with a line saying `Successfully installed (...) pythonanywhere- (...)`.
 
-Now we run the helper to automatically configure our app from GitHub. Type the following into the console on PythonAnywhere (don't forget to use your GitHub username in place of `<your-github-username>`):
+Now we run the helper to automatically configure our app from GitHub. Type the following into the console on PythonAnywhere (don't forget to use your GitHub username in place of `<your-github-username>`, so that the URL matches the clone URL from GitHub):
 
 {% filename %}PythonAnywhere command-line{% endfilename %}
 ```


### PR DESCRIPTION
As noted on #1332, the instructions said Copy but not Paste for the clone URL. So, changed to say to note the clone URL, and then when it is used twice later in the page, say something about how it should match the URL that you saw.

Fixes #1332 
