### PR TITLE
Clear up Python version confusion

### DIFF
--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -2,14 +2,14 @@
 
 > This section is based on a tutorial by Geek Girls Carrots (https://github.com/ggcarrots/django-carrots)
 
-Django is written in Python. We need Python to do anything in Django. Let's start by installing it! We want you to install Python 3.6, so if you have any earlier version, you will need to upgrade it.
+Django is written in Python. We need Python to do anything in Django. Let's start by installing it! We want you to install the latest version of Python 3, so if you have any earlier version, you will need to upgrade it, but if you already have version 3.4 to 3.7 you should be fine.
 
 
 <!--sec data-title="Install Python: Windows" data-id="python_windows" data-collapse=true ces-->
 
 First check whether your computer is running a 32-bit version or a 64-bit version of Windows, by pressing the Windows key + Pause/Break key which will open your System info, and look at the "System type" line. You can download Python for Windows from the website https://www.python.org/downloads/windows/. Click on the "Latest Python 3 Release - Python x.x.x" link. If your computer is running a **64-bit** version of Windows, download the **Windows x86-64 executable installer**. Otherwise, download the **Windows x86 executable installer**. After downloading the installer, you should run it (double-click on it) and follow the instructions there.
 
-One thing to watch out for: During the installation, you will notice a window marked "Setup". Make sure you tick the "Add Python 3.6 to PATH" checkbox and click on "Install Now", as shown here:
+One thing to watch out for: During the installation, you will notice a window marked "Setup". Make sure you tick the "Add Python 3.6 to PATH" or 'Add Python to your environment variables" checkbox and click on "Install Now", as shown here (it may look a bit different if you are installing a different version):
 
 ![Don't forget to add Python to the Path](../python_installation/images/python-installation-options.png)
 
@@ -18,7 +18,7 @@ In upcoming steps, you'll be using the Windows Command Line (which we'll also te
 ![Type "cmd" in the "Run" window](../python_installation/images/windows-plus-r.png)
 
 Note: if you are using an older version of Windows (7, Vista, or any older version) and the Python 3.6.x installer fails with an error, you can try either:
-1. install all Windows Updates and try to install Python 3.6 again; or
+1. install all Windows Updates and try to install Python again; or
 2. install an [older version of Python](https://www.python.org/downloads/windows/), e.g., [3.4.6](https://www.python.org/downloads/release/python-346/).
 
 If you install an older version of Python, the installation screen may look a bit different than shown above. Make sure you scroll down to see "Add python.exe to Path", then click the button on the left and pick "Will be installed on local hard drive":
@@ -50,7 +50,7 @@ $ python3 --version
 Python 3.6.1
 ```
 
-If you have a different 'micro version' of Python installed, e.g. 3.6.0, then you don't have to upgrade. If you don't have Python installed, or if you want a different version, you can install it as follows:
+If you have a different 'micro version' of Python installed, between 3.4.x and 3.7.x (e.g. 3.6.0), then you don't have to upgrade. If you don't have Python installed, or if you want a newer version, you can install it as follows:
 
 
 <!--endsec-->
@@ -61,7 +61,7 @@ Type this command into your console:
 
 {% filename %}command-line{% endfilename %}
 ```
-$ sudo apt install python3.6
+$ sudo apt install python3
 ```
 
 <!--endsec-->
@@ -100,7 +100,7 @@ $ python3 --version
 Python 3.6.1
 ```
 
-**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python 3.6.
+**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python between 3.4.x and 3.7.x.
 
 ----
 

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -50,7 +50,7 @@ $ python3 --version
 Python 3.6.1
 ```
 
-If you have a different version of Python installed, at least 3.4.x (e.g. 3.6.0), then you don't have to upgrade. If you don't have Python installed, or if you want a newer version, you can install it as follows:
+If you have a different version of Python installed, at least 3.4.0 (e.g. 3.6.0), then you don't have to upgrade. If you don't have Python installed, or if you want a newer version, you can install it as follows:
 
 
 <!--endsec-->

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -2,7 +2,7 @@
 
 > This section is based on a tutorial by Geek Girls Carrots (https://github.com/ggcarrots/django-carrots)
 
-Django is written in Python. We need Python to do anything in Django. Let's start by installing it! We want you to install the latest version of Python 3, so if you have any earlier version, you will need to upgrade it, but if you already have version 3.4 or higher you should be fine.
+Django is written in Python. We need Python to do anything in Django. Let's start by installing it! We want you to install the latest version of Python 3, so if you have any earlier version, you will need to upgrade it. If you already have version 3.4 or higher you should be fine.
 
 
 <!--sec data-title="Install Python: Windows" data-id="python_windows" data-collapse=true ces-->
@@ -50,7 +50,7 @@ $ python3 --version
 Python 3.6.1
 ```
 
-If you have a different 'micro version' of Python installed, at least 3.4.x (e.g. 3.6.0), then you don't have to upgrade. If you don't have Python installed, or if you want a newer version, you can install it as follows:
+If you have a different version of Python installed, at least 3.4.x (e.g. 3.6.0), then you don't have to upgrade. If you don't have Python installed, or if you want a newer version, you can install it as follows:
 
 
 <!--endsec-->

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -2,7 +2,7 @@
 
 > This section is based on a tutorial by Geek Girls Carrots (https://github.com/ggcarrots/django-carrots)
 
-Django is written in Python. We need Python to do anything in Django. Let's start by installing it! We want you to install the latest version of Python 3, so if you have any earlier version, you will need to upgrade it, but if you already have version 3.4 to 3.7 you should be fine.
+Django is written in Python. We need Python to do anything in Django. Let's start by installing it! We want you to install the latest version of Python 3, so if you have any earlier version, you will need to upgrade it, but if you already have version 3.4 or higher you should be fine.
 
 
 <!--sec data-title="Install Python: Windows" data-id="python_windows" data-collapse=true ces-->

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -50,7 +50,7 @@ $ python3 --version
 Python 3.6.1
 ```
 
-If you have a different 'micro version' of Python installed, between 3.4.x and 3.7.x (e.g. 3.6.0), then you don't have to upgrade. If you don't have Python installed, or if you want a newer version, you can install it as follows:
+If you have a different 'micro version' of Python installed, at least 3.4.x (e.g. 3.6.0), then you don't have to upgrade. If you don't have Python installed, or if you want a newer version, you can install it as follows:
 
 
 <!--endsec-->
@@ -101,7 +101,7 @@ Python 3.6.1
 ```
 The version shown may be different from 3.6.1 -- it should match the version you installed.
 
-**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python between 3.4.x and 3.7.x.
+**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python that is 3.4.x or higher.
 
 ----
 

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -99,6 +99,7 @@ Verify the installation was successful by opening a command prompt and running t
 $ python3 --version
 Python 3.6.1
 ```
+The version shown may be different from 3.6.1 -- it should match the version you installed.
 
 **NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python between 3.4.x and 3.7.x.
 

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -101,7 +101,7 @@ Python 3.6.1
 ```
 The version shown may be different from 3.6.1 -- it should match the version you installed.
 
-**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python that is 3.4.x or higher.
+**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python that is 3.4.0 or higher.
 
 ----
 


### PR DESCRIPTION
We have 3 open issues about Python version and package confusion. This PR attempts to fix them all:
- Fixes #1222: says that the python3.6 package is unavailable for Ubuntu, so the instructions are changed to use package python3
- Fixes #1259: talks about the fact that Linux installs probably already have Python. The instructions in this PR are changed to tell you which versions are OK and which ones you need to upgrade.
- Fixes #1322: talks about the Windows instructions, which both say to get the latest Python and to get 3.6. The instructions are updated to say to get the latest.
