### PR TITLE
Make clear that view does not return a function

### DIFF
--- a/en/django_views/README.md
+++ b/en/django_views/README.md
@@ -29,7 +29,7 @@ def post_list(request):
     return render(request, 'blog/post_list.html', {})
 ```
 
-As you can see, we created a function (`def`) called `post_list` that takes `request` and `return` a the value it gets from calling another function `render` that will render (put together) our template `blog/post_list.html`.
+As you can see, we created a function (`def`) called `post_list` that takes `request` and will `return` a the value it gets from calling another function `render` that will render (put together) our template `blog/post_list.html`.
 
 Save the file, go to http://127.0.0.1:8000/ and see what we've got.
 

--- a/en/django_views/README.md
+++ b/en/django_views/README.md
@@ -29,7 +29,7 @@ def post_list(request):
     return render(request, 'blog/post_list.html', {})
 ```
 
-As you can see, we created a function (`def`) called `post_list` that takes `request` and `return` a function `render` that will render (put together) our template `blog/post_list.html`.
+As you can see, we created a function (`def`) called `post_list` that takes `request` and `return` a the value it gets from calling another function `render` that will render (put together) our template `blog/post_list.html`.
 
 Save the file, go to http://127.0.0.1:8000/ and see what we've got.
 

--- a/en/django_views/README.md
+++ b/en/django_views/README.md
@@ -29,7 +29,7 @@ def post_list(request):
     return render(request, 'blog/post_list.html', {})
 ```
 
-As you can see, we created a function (`def`) called `post_list` that takes `request` and will `return` a the value it gets from calling another function `render` that will render (put together) our template `blog/post_list.html`.
+As you can see, we created a function (`def`) called `post_list` that takes `request` and will `return` the value it gets from calling another function `render` that will render (put together) our template `blog/post_list.html`.
 
 Save the file, go to http://127.0.0.1:8000/ and see what we've got.
 


### PR DESCRIPTION
Changes in this pull request:

- make clear that a regular value (the one returned by `render(...)` will be returned by the view
- switch that part of the sentence to future tense, to be somewhat more grammatical
