### PR TITLE
Accessibility fixes

### DIFF
--- a/en/css/README.md
+++ b/en/css/README.md
@@ -77,15 +77,13 @@ In your `blog/static/css/blog.css` file you should add the following code:
 
 {% filename %}blog/static/css/blog.css{% endfilename %}
 ```css
-h1 a {
+h1 a, h2 a {
     color: #C25100;
 }
-h2 a {
-    color: #C25100;
-}
+
 ```
 
-`h1 a` is a CSS Selector. This means we're applying our styles to any `a` element inside of an `h1` element (the `h2 a` selector does the same thing for `h2` elements). So when we have something like `<h1><a href="">link</a></h1>`, the `h1 a` style will apply. In this case, we're telling it to change its color to `#C25100`, which is a dark orange. Or you can put your own color here, but make sure it has good contrast against a white background!
+`h1 a` is a CSS Selector. This means we're applying our styles to any `a` element inside of an `h1` element; the `h2 a` selector does the same thing for `h2` elements. So when we have something like `<h1><a href="">link</a></h1>`, the `h1 a` style will apply. In this case, we're telling it to change its color to `#C25100`, which is a dark orange. Or you can put your own color here, but make sure it has good contrast against a white background!
 
 In a CSS file we determine styles for elements in the HTML file. The first way we identify elements is with the element name. You might remember these as tags from the HTML section. Things like `a`, `h1`, and `body` are all examples of element names.
 We also identify elements by the attribute `class` or the attribute `id`. Class and id are names you give the element by yourself. Classes define groups of elements, and ids point to specific elements. For example, you could identify the following tag by using the tag name `a`, the class `external_link`, or the id `link_to_wiki_page`:
@@ -171,11 +169,7 @@ Find the `h1 a` declaration block (the code between braces `{` and `}`) in the C
 
 {% filename %}blog/static/css/blog.css{% endfilename %}
 ```css
-h1 a {
-    color: #C25100;
-    font-family: 'Lobster';
-}
-h2 a {
+h1 a, h2 a {
     color: #C25100;
     font-family: 'Lobster';
 }

--- a/en/css/README.md
+++ b/en/css/README.md
@@ -70,7 +70,7 @@ Time to write some CSS! Open up the `blog/static/css/blog.css` file in your code
 
 We won't be going too deep into customizing and learning about CSS here. There is a recommendation for a free CSS course at the end of this page if you would like to learn more. 
 
-But let's do at least a little. Maybe we could change the color of our header?
+But let's do at least a little. Maybe we could change the color of our headers?
 To understand colors, computers use special codes. These codes start with `#` followed by 6 letters (A–F) and numbers (0–9). For example, the code for blue is `#0000FF`. You can find the color codes for many colors here: http://www.colorpicker.com/. You may also use [predefined colors](http://www.w3schools.com/colors/colors_names.asp), such as `red` and `green`.
 
 In your `blog/static/css/blog.css` file you should add the following code:
@@ -78,11 +78,14 @@ In your `blog/static/css/blog.css` file you should add the following code:
 {% filename %}blog/static/css/blog.css{% endfilename %}
 ```css
 h1 a {
-    color: #FCA205;
+    color: #C25100;
+}
+h2 a {
+    color: #C25100;
 }
 ```
 
-`h1 a` is a CSS Selector. This means we're applying our styles to any `a` element inside of an `h1` element. So when we have something like `<h1><a href="">link</a></h1>`, the `h1 a` style will apply. In this case, we're telling it to change its color to `#FCA205`, which is orange. Or you can put your own color here!
+`h1 a` is a CSS Selector. This means we're applying our styles to any `a` element inside of an `h1` element (the `h2 a` selector does the same thing for `h2` elements). So when we have something like `<h1><a href="">link</a></h1>`, the `h1 a` style will apply. In this case, we're telling it to change its color to `#C25100`, which is a dark orange. Or you can put your own color here, but make sure it has good contrast against a white background!
 
 In a CSS file we determine styles for elements in the HTML file. The first way we identify elements is with the element name. You might remember these as tags from the HTML section. Things like `a`, `h1`, and `body` are all examples of element names.
 We also identify elements by the attribute `class` or the attribute `id`. Class and id are names you give the element by yourself. Classes define groups of elements, and ids point to specific elements. For example, you could identify the following tag by using the tag name `a`, the class `external_link`, or the id `link_to_wiki_page`:
@@ -130,7 +133,7 @@ Your file should now look like this:
         {% for post in posts %}
             <div>
                 <p>published: {{ post.published_date }}</p>
-                <h1><a href="">{{ post.title }}</a></h1>
+                <h2><a href="">{{ post.title }}</a></h2>
                 <p>{{ post.text|linebreaksbr }}</p>
             </div>
         {% endfor %}
@@ -169,7 +172,11 @@ Find the `h1 a` declaration block (the code between braces `{` and `}`) in the C
 {% filename %}blog/static/css/blog.css{% endfilename %}
 ```css
 h1 a {
-    color: #FCA205;
+    color: #C25100;
+    font-family: 'Lobster';
+}
+h2 a {
+    color: #C25100;
     font-family: 'Lobster';
 }
 ```
@@ -196,7 +203,7 @@ And now add a class `post` to your `div` containing a blog post.
 ```html
 <div class="post">
     <p>published: {{ post.published_date }}</p>
-    <h1><a href="">{{ post.title }}</a></h1>
+    <h2><a href="">{{ post.title }}</a></h2>
     <p>{{ post.text|linebreaksbr }}</p>
 </div>
 ```
@@ -206,7 +213,7 @@ We will now add declaration blocks to different selectors. Selectors starting wi
 {% filename %}blog/static/css/blog.css{% endfilename %}
 ```css
 .page-header {
-    background-color: #ff9400;
+    background-color: #C25100;
     margin-top: 0;
     padding: 20px 20px 20px 40px;
 }
@@ -260,7 +267,7 @@ Then surround the HTML code which displays the posts with declarations of classe
 {% for post in posts %}
     <div class="post">
         <p>published: {{ post.published_date }}</p>
-        <h1><a href="">{{ post.title }}</a></h1>
+        <h2><a href="">{{ post.title }}</a></h2>
         <p>{{ post.text|linebreaksbr }}</p>
     </div>
 {% endfor %}
@@ -278,7 +285,7 @@ in the `blog/templates/blog/post_list.html` with this:
                     <div class="date">
                         <p>published: {{ post.published_date }}</p>
                     </div>
-                    <h1><a href="">{{ post.title }}</a></h1>
+                    <h2><a href="">{{ post.title }}</a></h2>
                     <p>{{ post.text|linebreaksbr }}</p>
                 </div>
             {% endfor %}

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -148,7 +148,7 @@ OK, so let's see how the HTML in `post_edit.html` should look:
 {% extends 'blog/base.html' %}
 
 {% block content %}
-    <h1>New post</h1>
+    <h2>New post</h2>
     <form method="POST" class="post-form">{% csrf_token %}
         {{ form.as_p }}
         <button type="submit" class="save btn btn-default">Save</button>
@@ -292,7 +292,7 @@ so that the template will look like this:
             </div>
         {% endif %}
         <a class="btn btn-default" href="{% url 'post_edit' pk=post.pk %}"><span class="glyphicon glyphicon-pencil"></span></a>
-        <h1>{{ post.title }}</h1>
+        <h2>{{ post.title }}</h2>
         <p>{{ post.text|linebreaksbr }}</p>
     </div>
 {% endblock %}

--- a/en/django_templates/README.md
+++ b/en/django_templates/README.md
@@ -54,7 +54,7 @@ It works! But we want the posts to be displayed like the static posts we created
 {% for post in posts %}
     <div>
         <p>published: {{ post.published_date }}</p>
-        <h1><a href="">{{ post.title }}</a></h1>
+        <h2><a href="">{{ post.title }}</a></h2>
         <p>{{ post.text|linebreaksbr }}</p>
     </div>
 {% endfor %}

--- a/en/extend_your_application/README.md
+++ b/en/extend_your_application/README.md
@@ -23,7 +23,7 @@ We will start with adding a link inside `blog/templates/blog/post_list.html` fil
             <div class="date">
                 {{ post.published_date }}
             </div>
-            <h1><a href="">{{ post.title }}</a></h1>
+            <h2><a href="">{{ post.title }}</a></h2>
             <p>{{ post.text|linebreaksbr }}</p>
         </div>
     {% endfor %}
@@ -147,7 +147,7 @@ It will look like this:
                 {{ post.published_date }}
             </div>
         {% endif %}
-        <h1>{{ post.title }}</h1>
+        <h2>{{ post.title }}</h2>
         <p>{{ post.text|linebreaksbr }}</p>
     </div>
 {% endblock %}

--- a/en/template_extending/README.md
+++ b/en/template_extending/README.md
@@ -44,7 +44,7 @@ Then open it up and copy everything from `post_list.html` to `base.html` file, l
                         <div class="date">
                             {{ post.published_date }}
                         </div>
-                        <h1><a href="">{{ post.title }}</a></h1>
+                        <h2><a href="">{{ post.title }}</a></h2>
                         <p>{{ post.text|linebreaksbr }}</p>
                     </div>
                 {% endfor %}
@@ -93,7 +93,7 @@ Now save `base.html` and open your `blog/templates/blog/post_list.html` again.
         <div class="date">
             {{ post.published_date }}
         </div>
-        <h1><a href="">{{ post.title }}</a></h1>
+        <h2><a href="">{{ post.title }}</a></h2>
         <p>{{ post.text|linebreaksbr }}</p>
     </div>
 {% endfor %}
@@ -112,7 +112,7 @@ Time to add block tags to this file!
             <div class="date">
                 {{ post.published_date }}
             </div>
-            <h1><a href="">{{ post.title }}</a></h1>
+            <h2><a href="">{{ post.title }}</a></h2>
             <p>{{ post.text|linebreaksbr }}</p>
         </div>
     {% endfor %}
@@ -131,7 +131,7 @@ Only one thing left. We need to connect these two templates together.  This is w
             <div class="date">
                 {{ post.published_date }}
             </div>
-            <h1><a href="">{{ post.title }}</a></h1>
+            <h2><a href="">{{ post.title }}</a></h2>
             <p>{{ post.text|linebreaksbr }}</p>
         </div>
     {% endfor %}


### PR DESCRIPTION
Partially fixes #1338 

Fixes the text in tutorial pages to use better contrast color in the CSS, and to only have one h1 header on a page (others are changed to h2).

Screenshots still need to be updated.