### PR TITLE
Fix path to PythonAnywhere beginner image

### DIFF
--- a/en/deploy/signup_pythonanywhere.md
+++ b/en/deploy/signup_pythonanywhere.md
@@ -5,7 +5,7 @@ Sign up for a "Beginner" account on PythonAnywhere (the free tier is fine, you d
 
 * [www.pythonanywhere.com](https://www.pythonanywhere.com/)
 
-![The PythonAnywhere signup page showing button to create a the free 'Beginner' account](images/pythonanywhere_beginner_account_button.png)
+![The PythonAnywhere signup page showing button to create a the free 'Beginner' account](../deploy/images/pythonanywhere_beginner_account_button.png)
 
 > **Note** When choosing your username here, bear in mind that your blog's URL will take the form `yourusername.pythonanywhere.com`, so choose either your own nickname or a name for what your blog is all about.
 


### PR DESCRIPTION
On https://tutorial.djangogirls.org/en/installation/ this image isn't displayed properly:

![image](https://user-images.githubusercontent.com/625793/44909291-1607c700-ad1f-11e8-808d-6e2f49d43a02.png)

Since the image below (creating an API token) is displayed, I'm assuming that the path has to look similar to that.