### PR TITLE
Change wording of "Basisverzeichnis"

### DIFF
--- a/de/deploy/README.md
+++ b/de/deploy/README.md
@@ -24,15 +24,15 @@ Git verwaltet die Veränderungen an einer Sammlung von Dateien in einem sogenann
 
 {% filename %}command-line{% endfilename %}
 
-    $ git init 
-    Initialized empty Git repository in ~/djangogirls/.git/ 
-    $ git config --global user.name "Dein Name" 
+    $ git init
+    Initialized empty Git repository in ~/djangogirls/.git/
+    $ git config --global user.name "Dein Name"
     $ git config --global user.email du@beispiel.com
-    
+
 
 Die Initialisierung des Git-Repositorys müssen wir für jedes Projekt nur einmal machen (danach musst Du Benutzernamen und Mail-Adresse nie wieder eingeben).
 
-Git wird die Änderungen an all den Dateien und Ordnern in diesem Verzeichnis aufzeichnen. Wir wollen aber, dass einige Dateien ignoriert werden. Dazu legen wir eine Datei `.gitignore` im Basisverzeichnis des Repos an. Öffne deinen Editor und erstelle eine neue Datei mit dem folgenden Inhalt:
+Git wird die Änderungen an all den Dateien und Ordnern in diesem Verzeichnis aufzeichnen. Wir wollen aber, dass einige Dateien ignoriert werden. Dazu legen wir eine Datei `.gitignore` im Hauptordner (`djangogirls`) des Repos an. Öffne deinen Editor und erstelle eine neue Datei mit dem folgenden Inhalt:
 
 {% filename %}.gitignore{% endfilename %}
 


### PR DESCRIPTION
I'm a participant from the djangogirls workshop in Zürich. During the coaching we recognized, that the wording in the german tutorial at "Veröffentlichen" in the django section isn't really clear for the participants. I changed the wording and deleted an empty line and three spaces. 
