### PR TITLE
pin version 3.3 of whitenoise

### DIFF
--- a/es/deploy/README.md
+++ b/es/deploy/README.md
@@ -194,10 +194,10 @@ Tal y como hiciste en tu propio ordenador, puedes crear un virtualenv en PythonA
     
     20:20 ~ $ source myvenv/bin/activate
     
-    (myvenv)20:20 ~ $  pip install django==1.8 whitenoise
+    (myvenv)20:20 ~ $  pip install django==1.8 whitenoise==3.3
     Collecting django
     [...]
-    Successfully installed django-1.8 whitenoise-1.0.6
+    Successfully installed django-1.8 whitenoise-3.3.0
     
 
 <!--TODO: think about using requirements.txt instead of pip install.-->


### PR DESCRIPTION
at the time of this writing, current (default) version is whitenoise==4.1. white noise 4.0 introduced breaking changes with respect to 3.3 that prevent the rest of the tutorial from working (http://whitenoise.evans.io/en/stable/changelog.html#v4-0)