### PR TITLE
Typo: Modified yum to show as a command

### DIFF
--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -76,7 +76,7 @@ Use this command in your console:
 $ sudo dnf install python3
 ```
 
-If you're on older Fedora versions you might get an error that the command `dnf` is not found. In that case, you need to use yum instead.
+If you're on older Fedora versions you might get an error that the command `dnf` is not found. In that case, you need to use `yum` instead.
 
 <!--endsec-->
 


### PR DESCRIPTION
Changes in this pull request:

- before: you need to use yum instead.
- after: you need to use `yum` instead.
