### PR TITLE
Update chromebook setup instructions

### DIFF
--- a/en/chromebook_setup/instructions.md
+++ b/en/chromebook_setup/instructions.md
@@ -2,26 +2,44 @@ You can [skip right over this section](http://tutorial.djangogirls.org/en/instal
 are, your installation experience will be a little different. You can ignore the
 rest of the installation instructions.
 
-### Cloud 9
+### Cloud IDE (PaizaCloud Cloud IDE, AWS Cloud9)
 
-Cloud 9 is a tool that gives you a code editor and access to a computer running
+Cloud IDE is a tool that gives you a code editor and access to a computer running
 on the Internet where you can install, write, and run the software. For the duration
-of the tutorial, Cloud 9 will act as your _local machine_. You'll still be
+of the tutorial, Cloud IDE will act as your _local machine_. You'll still be
 running commands in a terminal interface just like your classmates on OS X,
 Ubuntu, or Windows, but your terminal will be connected to a computer running
-somewhere else that Cloud 9 sets up for you.
+somewhere else that Cloud IDE sets up for you.
+Here is the instructions for Cloud IDEs(PaizaCloud Cloud IDE, AWS Cloud9).
 
-1. Install Cloud 9 from the [Chrome web store](https://chrome.google.com/webstore/detail/cloud9/nbdmccoknlfggadpfkmcpnamfnbkmkcp)
-2. Go to [c9.io](https://c9.io)
-3. Sign up for an account
-4. Click _Create a New Workspace_
-5. Name it _django-girls_
-6. Select the _Blank_ (second from the right on the bottom row with orange logo)
+#### PaizaCloud Cloud IDE
+
+1. Go to [PaizaCloud Cloud IDE](https://paiza.cloud/)
+2. Sign up for an account
+3. Click _New Server_
+4. Click Terminal button(on the left side of the window)
+
+Now you should see an interface with a sidebar, buttons at the left.
+Click "Terminal" button to open terminal window with prompt like this:
+
+{% filename %}Terminal{% endfilename %}
+```
+$
+```
+
+The terminal will give the computer Cloud 9 has prepared for your instructions.
+You can resize or maximize that window to make it a bit bigger.
+
+#### AWS Cloud9
+
+1. Go to [AWS Cloud9](https://aws.amazon.com/cloud9/)
+2. Sign up for an account
+3. Click _Create Environment_
 
 Now you should see an interface with a sidebar, a big main window with some
 text, and a small window at the bottom that looks something like this:
 
-{% filename %}Cloud 9{% endfilename %}
+{% filename %}bash{% endfilename %}
 ```
 yourusername:~/workspace $
 ```

--- a/en/chromebook_setup/instructions.md
+++ b/en/chromebook_setup/instructions.md
@@ -6,11 +6,12 @@ rest of the installation instructions.
 
 Cloud IDE is a tool that gives you a code editor and access to a computer running
 on the Internet where you can install, write, and run the software. For the duration
-of the tutorial, Cloud IDE will act as your _local machine_. You'll still be
+of the tutorial, cloud IDE will act as your _local machine_. You'll still be
 running commands in a terminal interface just like your classmates on OS X,
 Ubuntu, or Windows, but your terminal will be connected to a computer running
-somewhere else that Cloud IDE sets up for you.
-Here is the instructions for Cloud IDEs(PaizaCloud Cloud IDE, AWS Cloud9).
+somewhere else that cloud IDE sets up for you.
+Here is the instructions for cloud IDEs (PaizaCloud Cloud IDE, AWS Cloud9).
+You can choose one of the cloud IDEs, and follow the instruction of the cloud IDE.
 
 #### PaizaCloud Cloud IDE
 


### PR DESCRIPTION
c9.io is now AWS Cloud9, and the instruction need to be updated. Added other instruction for other cloud IDE(PaizaCloud).
