### PR TITLE
change 'auth.User' to settings.AUTH_USER_MODEL

### DIFF
--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -128,7 +128,7 @@ from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('settings.AUTH_USER_MODEL', on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -122,12 +122,13 @@ Let's open `blog/models.py` in the code editor, remove everything from it, and w
 
 {% filename %}blog/models.py{% endfilename %}
 ```python
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    author = models.ForeignKey('settings.AUTH_USER_MODEL', on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -152,6 +152,8 @@ Running migrations:
   Applying auth.0005_alter_user_last_login_null... OK
   Applying auth.0006_require_contenttypes_0002... OK
   Applying auth.0007_alter_validators_add_error_messages... OK
+  Applying auth.0008_alter_user_username_max_length... OK
+  Applying auth.0009_alter_user_last_name_max_length... OK
   Applying sessions.0001_initial... OK
 ```
 


### PR DESCRIPTION
connects to https://github.com/DjangoGirls/tutorial/issues/880

changes in this PR:
- alters the code snippet to use`settings.AUTH_USER_MODEL`
- updates console output of the database migrations, to reflect additional `auth` migrations