### PR TITLE
reword description of the Atom text editor

### DIFF
--- a/en/code_editor/instructions.md
+++ b/en/code_editor/instructions.md
@@ -17,7 +17,7 @@ Sublime Text is a very popular editor with a free evaluation period and it's ava
 
 ## Atom
 
-Atom is an extremely new code editor created by [GitHub](https://github.com/). It's free, open-source and available for Windows, OS X and Linux.
+Atom is another popular editor. It's free, open-source and available for Windows, OS X and Linux. Atom is developed by [GitHub](https://github.com/).
 
 [Download it here](https://atom.io/)
 


### PR DESCRIPTION
Removes the "new" description of Atom. 

The description of Atom was added to the tutorial in 2014 in [80612f9](https://github.com/djangogirls/tutorial/commit/80612f94572a3dcb3679d8ec373385fc45580d5e).
Atom had its 1.0 release in Jun 2015.  🎉 