### PR TITLE
Add more resources to "What's next?"

### DIFF
--- a/en/whats_next/README.md
+++ b/en/whats_next/README.md
@@ -4,21 +4,36 @@ Congratulate yourself! __You're totally awesome__. We're proud! <3
 
 ### What to do now?
 
-Take a break and relax. You have just done something really huge.
+Take a break and relax! You have just done something really huge.
 
 After that, make sure to follow Django Girls on [Facebook](http://facebook.com/djangogirls) or [Twitter](https://twitter.com/djangogirls) to stay up to date.
 
 ### Can you recommend any further resources?
 
-Yes! First, go ahead and try our other book, called [Django Girls Tutorial: Extensions](https://tutorial-extensions.djangogirls.org/).
+Yes! There are a _lot_ of resources online for learning all kinds of programming skills – it can be pretty daunting to work out where to go next, but we've got you covered. Whatever your interests were before you came to Django Girls, and whatever interests you've developed throughout the tutorial, here are some free resources (or resources with large free components) you can use to get to where you want to be.
 
-Later on, you can try the resources listed below. They're all very recommended!
+#### Django
+- Our other book, [Django Girls Tutorial: Extensions](https://tutorial-extensions.djangogirls.org/)
 - [Django's official tutorial](https://docs.djangoproject.com/en/2.0/intro/tutorial01/)
-- [New Coder tutorials](http://newcoder.io/tutorials/)
-- [Code Academy Python course](https://www.codecademy.com/en/tracks/python)
-- [Code Academy HTML & CSS course](https://www.codecademy.com/tracks/web)
-- [Django Carrots tutorial](https://github.com/ggcarrots/django-carrots)
-- [Learn Python The Hard Way book](http://learnpythonthehardway.org/book/)
 - [Getting Started With Django video lessons](http://www.gettingstartedwithdjango.com/)
-- [Two Scoops of Django 1.11: Best Practices for Django Web Framework book](https://www.twoscoopspress.com/products/two-scoops-of-django-1-11)
-- [Hello Web App: Learn How to Build a Web App](https://hellowebapp.com/) - you can also request a free eBook licence by contacting the author Tracy Osborn at [tracy@limedaring.com](mailto:tracy@limedaring.com)
+- [Django Carrots tutorial](https://github.com/ggcarrots/django-carrots)
+- [Hello Web App: Learn How to Build a Web App](https://hellowebbooks.com/learn-django/) – the course costs money but you can request a free eBook licence by contacting author Tracy Osborn at [tracy@limedaring.com](mailto:tracy@limedaring.com)
+
+#### HTML, CSS and JavaScript
+- [Codecademy's web development course](https://www.codecademy.com/learn/paths/web-development)
+- [freeCodeCamp](https://www.freecodecamp.org/)
+
+#### Python
+- [Codecademy's Python course](https://www.codecademy.com/learn/learn-python)
+- [Google's Python course](https://developers.google.com/edu/python/)
+- [Learn Python The Hard Way book](http://learnpythonthehardway.org/book/)
+- [New Coder tutorials](http://newcoder.io/tutorials/)
+- [edX](https://www.edx.org/course?search_query=python) – you can audit most courses for free, but if you want a certificate or credits towards a higher education qualification then that will cost money
+- [Coursera's Python courses](https://www.coursera.org/specializations/python) – some video lectures can be audited for free
+
+#### Working with data
+- [Codecademy's data science course](https://www.codecademy.com/learn/paths/data-science)
+- [edX](https://www.edx.org/course/?search_query=python&subject=Data%20Analysis%20%26%20Statistics) – you can audit most courses for free, but if you want a certificate or credits towards a higher education qualification then that will cost money
+- [Dataquest](https://www.dataquest.io/) – the first 30 "missions" are free
+
+We can't wait to see what you build next!

--- a/en/whats_next/README.md
+++ b/en/whats_next/README.md
@@ -16,7 +16,6 @@ Yes! There are a _lot_ of resources online for learning all kinds of programming
 - Our other book, [Django Girls Tutorial: Extensions](https://tutorial-extensions.djangogirls.org/)
 - [Django's official tutorial](https://docs.djangoproject.com/en/2.0/intro/tutorial01/)
 - [Getting Started With Django video lessons](http://www.gettingstartedwithdjango.com/)
-- [Django Carrots tutorial](https://github.com/ggcarrots/django-carrots)
 - [Hello Web App: Learn How to Build a Web App](https://hellowebbooks.com/learn-django/) – the course costs money but you can request a free eBook licence by contacting author Tracy Osborn at [tracy@limedaring.com](mailto:tracy@limedaring.com)
 
 #### HTML, CSS and JavaScript
@@ -26,8 +25,8 @@ Yes! There are a _lot_ of resources online for learning all kinds of programming
 #### Python
 - [Codecademy's Python course](https://www.codecademy.com/learn/learn-python)
 - [Google's Python course](https://developers.google.com/edu/python/)
-- [Learn Python The Hard Way book](http://learnpythonthehardway.org/book/)
-- [New Coder tutorials](http://newcoder.io/tutorials/)
+- [Learn Python The Hard Way book](http://learnpythonthehardway.org/book/) – the initial exercises are free
+- [New Coder tutorials](http://newcoder.io/tutorials/) – this is a variety of practical examples of how you might use Python
 - [edX](https://www.edx.org/course?search_query=python) – you can audit most courses for free, but if you want a certificate or credits towards a higher education qualification then that will cost money
 - [Coursera's Python courses](https://www.coursera.org/specializations/python) – some video lectures can be audited for free
 


### PR DESCRIPTION
After coaching a number of sessions over the last couple of years it's pretty clear that people come to the Django Girls tutorial for all kinds of reasons – maybe they want to create a website for their small business, maybe they want to use Python to help crunch data for their PhD – the audience is _really_ broad. With that in mind I wanted to flesh out and restructure the "What's next?" section of the tutorial to better help people find resources that are relevant to their interests so that they can better build on their experience of the tutorial.

The only resource I've removed from the original page is the book _Two Scoops of Django_ – I am a huge admirer of this book but I believe it is far too advanced to give to someone coming straight out of the Django Girls tutorial, and it costs money as well, unlike the other resources on the page.

I'm on the fence about adding links to Coursera and edX since there are paid-for components to their offerings, but I think there is enough free content there that they could still provide value to our audience.

Changes in this pull request:
- rewrote much of the text on the "What's next?" page
- added more free resources to the "What's next?" page
- grouped the resources into subgroups
