### PR TITLE
[1224] Modifies git on windows instructions

### DIFF
--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -5,7 +5,7 @@ Git is a "version control system" used by a lot of programmers. This software ca
 <!--sec data-title="Installing Git: Windows" data-id="git_install_windows"
 data-collapse=true ces-->
 
-You can download Git from [git-scm.com](https://git-scm.com/). You can hit "next" on all steps except for one; in the step entitled "Adjusting your PATH environment", choose "Use Git and optional Unix tools from the Windows Command Prompt" (the bottom option). Other than that, the defaults are fine. Checkout Windows-style, commit Unix-style line endings is good.
+You can download Git from [git-scm.com](https://git-scm.com/). You can hit "next" on all steps except for two: in the step where it asks to choose your editor, you should pick Nano, and in the step entitled "Adjusting your PATH environment", choose "Use Git and optional Unix tools from the Windows Command Prompt" (the bottom option). Other than that, the defaults are fine. Checkout Windows-style, commit Unix-style line endings is good.
 
 Do not forget to restart the command prompt or powershell after the installation finished successfully.
 <!--endsec-->


### PR DESCRIPTION
The installation of git for windows has changed, most importantly it has added a step to choose the default test editor for creating commits. The default is Vim, which is pretty unfriendly for newbies, so I suggest using Nano.

Fixes: https://github.com/DjangoGirls/tutorial/issues/1224
