### PR TITLE
Control + break for windows

### DIFF
--- a/en/django_urls/README.md
+++ b/en/django_urls/README.md
@@ -96,7 +96,7 @@ If you try to visit http://127.0.0.1:8000/ now, then you'll find some sort of 'w
 ![Error](images/error1.png)
 
 Your console is showing an error, but don't worry – it's actually pretty useful: It's telling you that there is __no attribute 'post_list'__. That's the name of the *view* that Django is trying to find and use, but we haven't created it yet. At this stage, your `/admin/` will also not work. No worries – we will get there.
-If you see a different error message, try restarting your web server. To do that, in the console window that is running the web server, stop it by pressing Ctrl+C (the Control and C keys together) and restart it by running a `python manage.py runserver` command.
+If you see a different error message, try restarting your web server. To do that, in the console window that is running the web server, stop it by pressing Ctrl+C (the Control and C keys together. On Windows, you might have to press Ctrl+Break) and restart it by running a `python manage.py runserver` command.
 
 
 > If you want to know more about Django URLconfs, look at the official documentation: https://docs.djangoproject.com/en/2.0/topics/http/urls/


### PR DESCRIPTION
It is introduced earlier in the tutorial that on windows, control + break can be used instead of control + c. From experience I know it is a good idea to repeat that here in the tutorial, as students may have forgotten. This will save them some confusion.

Changes in this pull request:

-
-
-
