### PR TITLE
also name LibreOffice when comparing Git to MSWord "track changes" feature

### DIFF
--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -1,4 +1,4 @@
-Git is a "version control system" used by a lot of programmers. This software can track changes to files over time so that you can recall specific versions later. A bit like the "track changes" feature in Microsoft Word, but much more powerful.
+Git is a "version control system" used by a lot of programmers. This software can track changes to files over time so that you can recall specific versions later. A bit like the "track changes" feature in word processor programs (e.g. Microsoft Word or LibreOffice Writer), but much more powerful.
 
 ## Installing Git
 

--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -1,4 +1,4 @@
-Git is a "version control system" used by a lot of programmers. This software can track changes to files over time so that you can recall specific versions later. A bit like the "track changes" feature in word processor programs (e.g. Microsoft Word or LibreOffice Writer), but much more powerful.
+Git is a "version control system" used by a lot of programmers. This software can track changes to files over time so that you can recall specific versions later. A bit like the "track changes" feature in word processor programs (e.g., Microsoft Word or LibreOffice Writer), but much more powerful.
 
 ## Installing Git
 


### PR DESCRIPTION
When comparing version control systems like Git to the "track changes" feature of word processor programs, not only the proprietary Microsoft Word (part of the Microsoft Office office suite) should be named, as the "track changes" feature is implemented in more than that one text processor / office suite. Also naming a FLOSS one (that is also available on FLOSS systems like GNU/Linux) seems required for completeness, and for the (probably still few) participants that never have used Microsoft software.