### PR TITLE
Fix PythonAnywhere command in Turkish translation

### DIFF
--- a/tr/deploy/README.md
+++ b/tr/deploy/README.md
@@ -158,7 +158,7 @@ Bu komut ekrana bir takım şeyler yazar, mesela `Collecting pythonanywhere`, an
 
 {% filename %}PythonAnywhere komut satırı{% endfilename %}
 
-    $ git clone https://github.com/<github-kullanıcı-adınız>/my-first-blog.git
+    $ pa_autoconfigure_django.py https://github.com/<github-kullanıcı-adınız>/my-first-blog.git
     
 
 Bu komut çalışırken neler olup bittiğini izleyebilirsiniz:


### PR DESCRIPTION
Changes in this pull request:

- Replace `git clone` command with the correct `pa_autoconfigure_django.py`