### PR TITLE
Fix issues on the Spanish translation

### DIFF
--- a/es/deploy/README.md
+++ b/es/deploy/README.md
@@ -124,7 +124,7 @@ Cuando hagas push a GitHub, te preguntará tu usuario y password de GitHub, y de
 
 <!--TODO: maybe do ssh keys installs in install party, and point ppl who dont have it to an extension -->
 
-Tu código ya está subido a GitHub. ¡Ve y compruébalo! Encontrarás que está en buena compañía - [Django](https://github.com/django/django)[Django Girlst Tutorial](https://github.com/DjangoGirls/tutorial), y muchos otros proyectos de software libre están alojados en GitHub. :)
+Tu código ya está subido a GitHub. ¡Ve y compruébalo! Encontrarás que está en buena compañía - [Django](https://github.com/django/django), [Django Girls Tutorial](https://github.com/DjangoGirls/tutorial) y muchos otros proyectos de software libre están alojados en GitHub. :)
 
 # Configurar nuestro blog en PythonAnywhere
 

--- a/es/django_templates/README.md
+++ b/es/django_templates/README.md
@@ -49,7 +49,23 @@ Prueba esto en tu plantilla.
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 
 ```html
-< div >< h1 >< a href = "/" > Django chicas Blog < /a >< / h1 >< / div >{% for post in posts %} < div >< p > publicado: {{ post.published_date }} < /p >< h1 >< a href = "" >{{ post.title }} < /a >< / h1 >< p >{{ post.text|linebreaksbr }} < /p >< / div >{% endfor %}
+<div>
+  <h1>
+    <a href="/">Django Girls Blog</a>
+  </h1>
+</div>
+
+<div>
+  {% for post in posts %}
+  <div>
+    <p> publicado: {{ post.published_date }}</p>
+      <h1>
+        <a href = "">{{ post.title }} </a>
+      </h1>
+    <p>{{ post.text|linebreaksbr }} </p>
+  </div>
+  {% endfor %}
+</div>
 ```
 
 {% raw %}Todo lo que pongas entre `{% for %}` y `{% endfor %}` se repetirá para cada objeto de la lista. Refresca la página:{% endraw %}

--- a/es/dynamic_data_in_templates/README.md
+++ b/es/dynamic_data_in_templates/README.md
@@ -56,7 +56,7 @@ def post_list(request):
     return render(request, 'blog/post_list.html', {})
 ```
 
-La última parte es pasar el QuerySet `posts` a la plantilla context. No te preocupes, mostraremos como mostrarlo más adelante.
+La última parte que nos falta es pasar el QuerySet `posts` a la plantilla context. No te preocupes, enseñaremos como mostrarlo más adelante.
 
 Fíjate en que creamos una *variable* para el QuerySet: `posts`. Trátala como si fuera el nombre de nuestro QuerySet. De aquí en adelante vamos a referirnos al QuerySet con ese nombre.
 

--- a/es/dynamic_data_in_templates/README.md
+++ b/es/dynamic_data_in_templates/README.md
@@ -1,6 +1,6 @@
 # Datos dinámicos en plantillas
 
-Tenemos diferentes piezas en su lugar: el modelo `Post` está definido en `models.py`, tenemos a `post_list` en `views.py` y la plantilla agregada. ¿Pero cómo haremos realmente para que nuestros posts aparezcan en nuestra plantilla HTML? Porque eso es lo que queremo, tomar algún contenido (modelos guardados en la base de datos) y mostrarlo adecuadamente en nuestra plantilla, ¿no?
+Tenemos diferentes piezas en su lugar: el modelo `Post` está definido en `models.py`, tenemos a `post_list` en `views.py` y la plantilla agregada. ¿Pero cómo haremos realmente para que nuestros posts aparezcan en nuestra plantilla HTML? Porque eso es lo que queremos, tomar algún contenido (modelos guardados en la base de datos) y mostrarlo adecuadamente en nuestra plantilla, ¿no?
 
 Esto es exactamente lo que las *views* se supone que hacen: conectar modelos con plantillas. En nuestra *view* `post_list` necesitaremos tomar los modelos que deseamos mostrar y pasarlos a una plantilla. En una *vista* decidimos que (modelo) se mostrará en una plantilla.
 

--- a/es/intro_to_command_line/README.md
+++ b/es/intro_to_command_line/README.md
@@ -409,7 +409,7 @@ Aquí hay una lista de algunos comandos útiles:
 
 | Comando (Windows) | Comando (Mac OS / Linux) | Descripción                  | Ejemplo                                           |
 | ----------------- | ------------------------ | ---------------------------- | ------------------------------------------------- |
-| salida            | salida                   | Cierra la ventana            | **salida**                                        |
+| exit              | exit                     | Cierra la ventana            | **exit**                                        |
 | cd                | cd                       | Cambia el directorio         | **cd test**                                       |
 | cd                | pwd                      | Mostrar el directorio actual | **cd** (Windows) o **pwd** (Mac OS / Linux)       |
 | dir               | ls                       | Lista directorios/archivos   | **dir**                                           |

--- a/es/python_introduction/README.md
+++ b/es/python_introduction/README.md
@@ -98,7 +98,7 @@ Usar comillas dobles:
 "Runnin' down the hill"
 ```
 
-o escapar el apóstrofe con la diagonal inversa (``):
+o escapar el apóstrofe con la diagonal inversa ( \ ):
 
 {% filename %}command-line{% endfilename %}
 


### PR DESCRIPTION
The terminal command "exit" shouldn't be translated.

Changes in this pull request:

- the word "**salida**" was corrected to the command name "**exit**"
