### PR TITLE
fix ls output (at deploy chapter)

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -187,8 +187,8 @@ Now, if you like, you can also take a look at your code on PythonAnywhere using 
 (ola.pythonanywhere.com) $ ls
 blog  db.sqlite3  manage.py  mysite requirements.txt static
 (ola.pythonanywhere.com) $ ls blog/
-__init__.py  __pycache__  admin.py  forms.py  migrations  models.py  static
-templates  tests.py  urls.py  views.py
+__init__.py  __pycache__  admin.py  apps.py  migrations  models.py
+tests.py  views.py
 ```
 
 You can also go to the "Files" page and navigate around using PythonAnywhere's built-in file browser. (From the Console page, you can get to other PythonAnywhere pages from the menu button in the upper right corner. Once you're on one of the pages, there are links to the other ones near the top.)


### PR DESCRIPTION
based on issue #1314

Changes in this pull request:

- fix `ls blog/`output (typed at pythonanywhere)
  - add `apps.py`
  - delete `forms.py`, `static` folder, `templates` folder and `urls.py` because they are not yet created at deploy chapter

Fixes #1314 