### PR TITLE
Added small note to use `python` instead of `python3` for Windows.

### DIFF
--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -167,6 +167,8 @@ Before we do that, we should make sure we have the latest version of `pip`, the 
 (myvenv) ~$ python3 -m pip install --upgrade pip
 ```
 
+**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) instead.
+
 ### Installing packages with requirements
 
 A requirements file keeps a list of dependencies to be installed using

--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -164,10 +164,8 @@ Before we do that, we should make sure we have the latest version of `pip`, the 
 
 {% filename %}command-line{% endfilename %}
 ```
-(myvenv) ~$ python3 -m pip install --upgrade pip
+(myvenv) ~$ python -m pip install --upgrade pip
 ```
-
-**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) instead.
 
 ### Installing packages with requirements
 


### PR DESCRIPTION
Changes in this pull request:

- Update command step to use `python` instead of `python3` since we are working within the virtual environment. 

Thank you! :) 
