### PR TITLE
syntax fixed

### DIFF
--- a/en/chromebook_setup/instructions.md
+++ b/en/chromebook_setup/instructions.md
@@ -45,8 +45,8 @@ text, and a small window at the bottom that looks something like this:
 yourusername:~/workspace $
 ```
 
-This bottom area is your _terminal_, where you will give the computer Cloud 9
-has prepared for your instructions. You can resize that window to make it a bit
+This bottom area is your _terminal_. You can use the terminal to send instructions
+to the remote Cloud 9 computer. You can resize that window to make it a bit
 bigger.
 
 ### Virtual Environment

--- a/en/chromebook_setup/instructions.md
+++ b/en/chromebook_setup/instructions.md
@@ -45,7 +45,7 @@ text, and a small window at the bottom that looks something like this:
 yourusername:~/workspace $
 ```
 
-This bottom area is your _terminal_. You can use the terminal to send instructions
+This bottom area is your terminal. You can use the terminal to send instructions
 to the remote Cloud 9 computer. You can resize that window to make it a bit
 bigger.
 


### PR DESCRIPTION
Changes in this pull request:

I've changed this sentence "This bottom area is your _terminal_, where you will give the computer Cloud 9
has prepared for your instructions" 
into:
"This bottom area is your terminal. You can use the terminal to send instructions
to the remote Cloud 9 computer."
