### PR TITLE
add slash to make code snippet consistent

### DIFF
--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -91,7 +91,7 @@ We open `blog/urls.py` in the code editor and add a line:
 
 {% filename %}blog/urls.py{% endfilename %}
 ```python
-path('post/new', views.post_new, name='post_new'),
+path('post/new/', views.post_new, name='post_new'),
 ```
 
 And the final code will look like this:


### PR DESCRIPTION
Changes in this pull request:

- Code Fix:
added missing slash, so that code snippet is consistent with the immediately preceding one.

Other than claimed in the original description, skipping the slash doesn't cause any technical problems, but the inconsistency might confuse readers.

### original description:

Changes in this pull request:

- Code Fix:
added missing slash, since the original produced an error when implemented
