### PR TITLE
use inline code markup for part of CLI input

### DIFF
--- a/en/chromebook_setup/instructions.md
+++ b/en/chromebook_setup/instructions.md
@@ -77,7 +77,7 @@ source myvenv/bin/activate
 pip install django~={{ book.django_version }}
 ```
 
-(note that on the last line we use a tilde followed by an equal sign: ~=).
+(note that on the last line we use a tilde followed by an equal sign: `~=`).
 
 ### GitHub
 


### PR DESCRIPTION
Changes in this pull request:

- added inline code (monospace) around "~="