### PR TITLE
[en] mention possibly translated dir name for "Desktop" at first occurrence

### DIFF
--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -202,11 +202,12 @@ data-collapse=true ces-->
 $ cd Desktop
 ```
 
-(The directory name "Desktop" might be translated
+Note that
+the directory name "Desktop" might be translated
 to the language of your Linux account.
 If that's the case, you'll need to replace `Desktop`
 with the translated name,
-for example `Schreibtisch` for German.)
+for example `Schreibtisch` for German.
 
 <!--endsec-->
 

--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -185,7 +185,7 @@ Music
 
 Now, let's go to our Desktop directory:
 
-<!--sec data-title="Change directory: OS X" data-id="python_OSX" data-collapse=true ces-->
+<!--sec data-title="Change current directory: OS X" data-id="OSX_move_to" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -193,7 +193,7 @@ $ cd Desktop
 ```
 <!--endsec-->
 
-<!--sec data-title="Change directory: Linux" data-id="python_linux" data-collapse=true ces-->
+<!--sec data-title="Change current directory: Linux" data-id="Linux_move_to" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```

--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -205,7 +205,8 @@ $ cd Desktop
 (The directory name "Desktop" might be translated
 to the language of your Linux account.
 If that's the case, you'll need to replace `Desktop`
-with the translated name, for example `Schreibtisch` for German.)
+with the translated name,
+for example `Schreibtisch` for German.)
 
 <!--endsec-->
 

--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -185,8 +185,7 @@ Music
 
 Now, let's go to our Desktop directory:
 
-<!--sec data-title="Change directory: OS X" data-id="python_OSX"
-data-collapse=true ces-->
+<!--sec data-title="Change directory: OS X" data-id="python_OSX" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -194,8 +193,7 @@ $ cd Desktop
 ```
 <!--endsec-->
 
-<!--sec data-title="Change directory: Linux" data-id="python_linux"
-data-collapse=true ces-->
+<!--sec data-title="Change directory: Linux" data-id="python_linux" data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```

--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -205,7 +205,7 @@ $ cd Desktop
 (The directory name "Desktop" might be translated
 to the language of your Linux account.
 If that's the case, you'll need to replace `Desktop`
-with the translated name, e.g. `Schreibtisch` for German.)
+with the translated name, for example `Schreibtisch` for German.)
 
 <!--endsec-->
 

--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -206,8 +206,8 @@ Note that
 the directory name "Desktop" might be translated
 to the language of your Linux account.
 If that's the case, you'll need to replace `Desktop`
-with the translated name,
-for example `Schreibtisch` for German.
+with the translated name;
+for example, `Schreibtisch` for German.
 
 <!--endsec-->
 

--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -185,12 +185,28 @@ Music
 
 Now, let's go to our Desktop directory:
 
-<!--sec data-title="Change current directory: OS X and Linux" data-id="OSX_Linux_move_to" data-collapse=true ces-->
+<!--sec data-title="Change directory: OS X" data-id="python_OSX"
+data-collapse=true ces-->
 
 {% filename %}command-line{% endfilename %}
 ```
 $ cd Desktop
 ```
+<!--endsec-->
+
+<!--sec data-title="Change directory: Linux" data-id="python_linux"
+data-collapse=true ces-->
+
+{% filename %}command-line{% endfilename %}
+```
+$ cd Desktop
+```
+
+(The directory name "Desktop" might be translated
+to the language of your Linux account.
+If that's the case, you'll need to replace `Desktop`
+with the translated name, e.g. `Schreibtisch` for German.)
+
 <!--endsec-->
 
 <!--sec data-title="Change current directory: Windows" data-id="windows_move_to" data-collapse=true ces-->

--- a/en/python_introduction/README.md
+++ b/en/python_introduction/README.md
@@ -602,12 +602,14 @@ $ cd ~/Desktop
 <!--sec data-title="Change directory: Linux" data-id="python_linux"
 data-collapse=true ces-->
 
-On Linux, it will be like this (the word "Desktop" might be translated to your local language):
+On Linux, it will be like this:
 
 {% filename %}command-line{% endfilename %}
 ```
 $ cd ~/Desktop
 ```
+
+(Remember that the word "Desktop" might be translated to your local language.)
 
 <!--endsec-->
 


### PR DESCRIPTION
Changes in this pull request:

- Mention the possibility of the "Desktop" subfolder of Linux user home folder to be localized when that folder _first_ occurs in a command (in the command line intro chapter)
  - (For that, introduce separate expandable sections for Linux and OS X)
  - Give an example of a translated name. (I've chosen the German "Schreibtisch".)
- Adapt the existing remark at a later occurrence (in the python intro chapter) accordingly

This should ...
- ... help people following the English original of the tutorial despite having localized folder names. (E.g. because no (complete) translation of the tutorial is available for that language.)
- ... remind translators that they should mention how these folders are named on Linux accounts in the respective language.