### PR TITLE
correct language w.r.t. QuerySet method chaining

### DIFF
--- a/en/django_orm/README.md
+++ b/en/django_orm/README.md
@@ -192,8 +192,11 @@ We can also reverse the ordering by adding `-` at the beginning:
 
 ### Complex queries through method-chaining
 
-As you saw, some QuerySet methods return a new QuerySet.
-You can combine their effect by **chaining** them together:
+As you saw, some methods on `Post.objects` return a QuerySet.
+The same methods can in turn also be called on a QuerySet,
+and will then return a new QuerySet.
+Thus,
+you can combine their effect by **chaining** them together:
 
 ```python
 >>> Post.objects.filter(published_date__lte=timezone.now()).order_by('published_date')

--- a/en/django_orm/README.md
+++ b/en/django_orm/README.md
@@ -190,9 +190,10 @@ We can also reverse the ordering by adding `-` at the beginning:
 ```
 
 
-### Chaining QuerySets 
+### Complex queries through method-chaining
 
-You can also combine QuerySets by **chaining** them together:
+As you saw, some QuerySet methods return a new QuerySet.
+You can combine their effect by **chaining** them together:
 
 ```python
 >>> Post.objects.filter(published_date__lte=timezone.now()).order_by('published_date')


### PR DESCRIPTION
Not QuerySets can be chained, but their method calls can.

Changes in this pull request:

- Mention that some QuerySet methods themselves return a QuerySet
- Correct language: It's the method( call)s that can be chained/combined, not several QuerySets.
- Change h3-section title to reflect this new content.

This is an alternative change to the one proposed at #1311. Other than #1311, this change **doesn't** try to explain how to combine several QuerySets with the `union` method, which isn't needed for the tutorial anyway.