### PR TITLE
cache NPM packages on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: node_js
 node_js:
   - "8"
 
-cache:
-  directories:
-    - "DjangoGirls/turorial"
+cache: npm
 
 install:
   - npm install gitbook-cli -g


### PR DESCRIPTION
Changes in this pull request:

- remove cached-directory entry that
  - contained a typo
  - probably wouldn't have matched anything, anyway, as the [cached-directory paths are relative to the `$TRAVIS_BUILD_DIR`](https://docs.travis-ci.com/user/caching/#arbitrary-directories), which already would be the cloned Git repo root.
- add [shortcut to cache NPM packages](https://docs.travis-ci.com/user/caching/#npm-cache)

Fixes #1469