### PR TITLE
consider the German translation stable and remove the "(beta)" designation

### DIFF
--- a/LANGS.md
+++ b/LANGS.md
@@ -1,6 +1,6 @@
 * [🇺🇸 English](en/)
 * [🇨🇿 Čeština (beta)](cs/)
-* [🇩🇪 Deutsch (beta)](de/)
+* [🇩🇪 Deutsch](de/)
 * [🇬🇷 Ελληνικά (beta)](el/)
 * [🇪🇸 Español (beta)](es/)
 * [🇫🇷 Français](fr/)


### PR DESCRIPTION
Changes in this pull request:

- remove the "(beta)" designation from "Deutsch" in the language listing

Rationale:

The German translation is recently and currently very well-maintained and kept closely up-to-date with the English tutorial. Most recent changes and additions to it have been peer-proofread. The remainder is by now field-proven through use in various workshops.