### PR TITLE
Fix command for installation on Debian and Ubuntu

### DIFF
--- a/es/python_installation/instructions.md
+++ b/es/python_installation/instructions.md
@@ -60,7 +60,7 @@ Escribe este comando en tu consola:
 
 {% filename %}command-line{% endfilename %}
 
-    sudo yum install python3.6
+    $ sudo apt install python3.6
     
 
 <!--endsec-->


### PR DESCRIPTION
This change fix the command line section for installing Python on Debian and it derivatives.
