### PR TITLE
Corrige nombre de variable STATIC_ROOT

### DIFF
--- a/es/django_start_project/README.md
+++ b/es/django_start_project/README.md
@@ -90,7 +90,7 @@ Si quieres un idioma diferente, cambia el código de idioma cambiando la siguien
 LANGUAGE_CODE = 'es-es'
 ```
 
-También tenemos que añadir una ruta para archivos estáticos. (Veremos todo acerca de archivos estáticos y CSS más adelante.) Ve al *final* del archivo, y justo debajo de la entrada `STATIC_URL`, añade una nueva llamada `STATIC_ROOR`:
+También tenemos que añadir una ruta para archivos estáticos. (Veremos todo acerca de archivos estáticos y CSS más adelante.) Ve al *final* del archivo, y justo debajo de la entrada `STATIC_URL`, añade una nueva llamada `STATIC_ROOT`:
 
 {% filename %}mysite/settings.py{% endfilename %}
 


### PR DESCRIPTION
En el párrafo de configuración de rutas para archivos estáticos, modifica nombre de variable STATIC_ROOR por STATIC_ROOT

Changes in this pull request:

- Changes variable name from STATIC_ROOR to STATIC_ROOT

