### PR TITLE
Add text to prev/next and top menu icons, so they are easier to notice and understand

### DIFF
--- a/en/styles/website.css
+++ b/en/styles/website.css
@@ -1,0 +1,57 @@
+
+/* add text to top menu items */
+
+.book-header .fa::after {
+    text-transform: none;
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+.book-header .fa-align-justify::after {
+    content: ' Show Contents';
+    text-transform: none;
+    font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+.book.with-summary .book-header .fa-align-justify::after {
+    content: ' Hide Contents';
+}
+.book-header .fa-globe::after {
+    content: ' Language';
+}
+.book-header .fa-font::after {
+    content: ' Font Settings';
+}
+
+
+/* add text to the Next & Prev arrows */
+
+.navigation-prev::after {
+    content: 'Previous';
+    font-size: 20pt;
+    vertical-align: text-bottom;
+    line-height: 44px;
+}
+.navigation-next::after {
+    content: 'Next';
+    font-size: 20pt;
+    vertical-align: text-bottom;
+    line-height: 44px;
+}
+
+@media (max-width:1240px) {
+    /* on small viewports, the arrows are shown on the side, so move text around to look better */
+    .navigation-next::after {
+        content: none;
+    }
+    .navigation-next::before {
+        content: 'Next';
+        font-size: 20pt;
+        vertical-align: text-bottom;
+        line-height: 44px;
+    }
+}
+
+/* fine tune text size to not overlap main body text on very specific viewport sizes */
+@media (min-width:1241px) and (max-width:1274px) {
+    .navigation-prev::after {
+        font-size: 16pt;
+    }
+}


### PR DESCRIPTION
This addresses issues #1054 and #1055 although may not satisfy all the ideas/requests from the original reporter.  Further changes I think would involve gitbook core or theme customizations, which would be a much bigger undertaking.

I could also hide the social sharing icons in the upper right, to declutter that if we don't think they are useful.  I wasn't sure though.