### PR TITLE
Django apps have their own urls.py file

### DIFF
--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -88,6 +88,7 @@ djangogirls
 │   │   └── __init__.py
 │   ├── models.py
 │   ├── tests.py
+|   ├── urls.py
 │   └── views.py
 ├── db.sqlite3
 ├── manage.py


### PR DESCRIPTION
Hey, I noticed this issue, and this could be fixed fairly easily. I did it only for English, I did not check any of the other languages. If you would like me to, I could.

Changes in this pull request:

- Add a line to django_models tutorial page
