### PR TITLE
Make navigation bar fit better on small screens. Reword to Show Outline

### DIFF
--- a/en/styles/website.css
+++ b/en/styles/website.css
@@ -6,12 +6,12 @@
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 .book-header .fa-align-justify::after {
-    content: ' Show Contents';
+    content: ' Show Outline';
     text-transform: none;
     font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 }
 .book.with-summary .book-header .fa-align-justify::after {
-    content: ' Hide Contents';
+    content: ' Hide Outline';
 }
 .book-header .fa-globe::after {
     content: ' Language';
@@ -19,7 +19,14 @@
 .book-header .fa-font::after {
     content: ' Font Settings';
 }
-
+@media (max-width:600px) {
+    .book-header .fa-font::after {
+        content: ' Font';
+    }
+    .book-header .js-toolbar-action.pull-right {  /* social sharing links */
+        display: none;
+    }
+}
 
 /* add text to the Next & Prev arrows */
 


### PR DESCRIPTION
This is a followup for #1495 to address feedback in this comment: https://github.com/DjangoGirls/tutorial/pull/1495#issuecomment-479446680

It changes small screens from:
![screenshot 2019-04-10 21-17-13](https://user-images.githubusercontent.com/19553/55924408-c86a0b80-5bd7-11e9-9033-2a9d606718cc.png)

To be like:
![screenshot 2019-04-10 21-27-31](https://user-images.githubusercontent.com/19553/55924412-cdc75600-5bd7-11e9-914e-7053ceb41c18.png)
