### PR TITLE
add GitHub CODEOWNERS using the existing PR review teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# default:
+*	@DjangoGirls/committers
+
+# language PR review teams for the respective translations:
+/de/	@DjangoGirls/de-pr
+/en/	@DjangoGirls/en-pr
+/es/	@DjangoGirls/es-pr
+/fr/	@DjangoGirls/fr-pr
+/it/	@DjangoGirls/it-pr
+/ja/	@DjangoGirls/ja-pr
+/ko/	@DjangoGirls/ko-pr
+/pl/	@DjangoGirls/pl-pr
+/pt/	@DjangoGirls/pt-pr
+/ru/	@DjangoGirls/ru-pr
+/tr/	@DjangoGirls/tr-pr
+/uk/	@DjangoGirls/uk-pr
+/zh/	@DjangoGirls/cn-pr


### PR DESCRIPTION
Add [GitHub CODEOWNERS](https://help.github.com/en/articles/about-code-owners) using the existing PR review teams from https://github.com/orgs/DjangoGirls/teams (an idea brought up by https://github.com/DjangoGirls/tutorial/issues/1271#issuecomment-392542583)

This will automatically request reviews of the respective teams for pull requests touching "their" files, but won't require these reviews for merging.