### PR TITLE
Wrong variable name displays an error

### DIFF
--- a/ja/python_introduction/README.md
+++ b/ja/python_introduction/README.md
@@ -230,10 +230,10 @@ name イコール（=）"Ola" とタイプします。
 
 ```python
 >>> city = "Tokyo"
->>> ctiy
+>>> citty
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-NameError: name 'ctiy' is not defined
+NameError: name 'citty' is not defined
 ```
 
 エラーになりました！ 前回とは違うエラータイプです。**NameError** という、初めてみるエラータイプですね。 作成されていない変数を使った時は、Pythonがエラーを教えてくれます。 もし、このエラーに出くわしたら、記述したコードにタイプミスがないか確認してください。


### PR DESCRIPTION
Changes in this pull request:

- Change to Wrong variable name

`ctiy` looks similar to the actual word `city` if you do not pay enough attention. Actually my co-worker who just started to do tutorial typed  `city` and wondered why it did not show as an error.