### PR TITLE
Fix bug where Windows information isn't collapsing in intro to command line

### DIFF
--- a/en/intro_to_command_line/open_instructions.md
+++ b/en/intro_to_command_line/open_instructions.md
@@ -1,3 +1,4 @@
+
 <!--sec data-title="Opening: Windows" data-id="windows_prompt" data-collapse=true ces-->
 
 Depending on your version of Windows and your keyboard, one of the following should open a command window (you may have to experiment a bit, but you don't have to try all of these suggestions):


### PR DESCRIPTION
Fixes a small bug where Windows information wasn't inside of the collapsible section under "Brief intro to the command line": https://tutorial.djangogirls.org/en/installation/#brief-intro-to-the-command-line

I've tested this locally using `gitbook serve` to confirm it fixes the issue. Seems like it's really a bug in gitbook but easy enough for us to fix on our side.

Changes in this pull request:
- Added a single line to `en/intro_to_command_line/open_instructions.md`