### PR TITLE
Add note about pre-opened cmd on Windows

### DIFF
--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -111,7 +111,7 @@ Python 3.6.1
 ```
 The version shown may be different from 3.6.1 -- it should match the version you installed.
 
-**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python that is 3.4.0 or higher.
+**NOTE:** If you're on Windows and you get an error message that `python3` wasn't found, try using `python` (without the `3`) and check if it still might be a version of Python that is 3.4.0 or higher. If that doesn't work either, you may open a new command prompt and try again; this happens if you use a command prompt left open from before the Python installation. 
 
 ----
 


### PR DESCRIPTION
Added it to the Note at the bottom about handling "command not found" on Windows.

I considered adding a note in the Windows installation instructions, telling the user to close any pre-open command prompt. This is probably better operationally (prevent the error instead of handle it), but I couldn't find a satisfactory way to put it in the narrative.