### PR TITLE
Update Django version to 2.2 LTS

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,7 +1,7 @@
 {
     "gitbook": ">=3.2.0",
     "variables": {
-      "django_version": "2.0.6"
+      "django_version": "2.2.4"
     },
     "links": {
         "sidebar": {

--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -157,7 +157,7 @@ Now we run the helper to automatically configure our app from GitHub. Type the f
 
 {% filename %}PythonAnywhere command-line{% endfilename %}
 ```
-$ pa_autoconfigure_django.py https://github.com/<your-github-username>/my-first-blog.git
+$ pa_autoconfigure_django.py --python=3.6 https://github.com/<your-github-username>/my-first-blog.git
 ```
 
 As you watch that running, you'll be able to see what it's doing:

--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -210,6 +210,7 @@ If you see an error while running the `pa_autoconfigure_django.py` script, here 
 - Forgetting to create your PythonAnywhere API token.
 - Making a mistake in your GitHub URL
 - If you see an error saying *"Could not find your settings.py"*, it's probably because you didn't manage to add all your files to Git, and/or you didn't push them up to GitHub successfully.  Have another look at the Git section above
+- If you previously signed up for a PythonAnywhere account and had an error with collectstatic, you probably have an older version of SQLite (eg 3.8.2) for your account. In that case, sign up for a new account and try the commands in the PythonAnywhere section above.
 
 
 If you see an error when you try to visit your site, the first place to look for some debugging info is in your **error log**. You'll find a link to this on the PythonAnywhere ["Web" page](https://www.pythonanywhere.com/web_app_setup/). See if there are any error messages in there; the most recent ones are at the bottom.

--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -199,7 +199,7 @@ You can also go to the "Files" page and navigate around using PythonAnywhere's b
 Your site should now be live on the public Internet!  Click through to the PythonAnywhere "Web" page to get a link to it. You can share this with anyone you want :)
 
 
-> **Note** This is a beginners' tutorial, and in deploying this site we've taken a few shortcuts which aren't ideal from a security point of view.  If and when you decide to build on this project, or start a new project, you should review the [Django deployment checklist](https://docs.djangoproject.com/en/2.0/howto/deployment/checklist/) for some tips on securing your site.
+> **Note** This is a beginners' tutorial, and in deploying this site we've taken a few shortcuts which aren't ideal from a security point of view.  If and when you decide to build on this project, or start a new project, you should review the [Django deployment checklist](https://docs.djangoproject.com/en/2.2/howto/deployment/checklist/) for some tips on securing your site.
 
 
 ## Debugging tips

--- a/en/django_admin/README.md
+++ b/en/django_admin/README.md
@@ -52,6 +52,6 @@ Make sure that at least two or three posts (but not all) have the publish date s
 
 ![Django admin](images/edit_post3.png)
 
-If you want to know more about Django admin, you should check Django's documentation: https://docs.djangoproject.com/en/2.0/ref/contrib/admin/
+If you want to know more about Django admin, you should check Django's documentation: https://docs.djangoproject.com/en/2.2/ref/contrib/admin/
 
 This is probably a good moment to grab a coffee (or tea) or something to eat to re-energize yourself. You created your first Django model – you deserve a little break!

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -352,7 +352,7 @@ Feel free to change the title or the text and save the changes!
 
 Congratulations! Your application is getting more and more complete!
 
-If you need more information about Django forms, you should read the documentation: https://docs.djangoproject.com/en/2.0/topics/forms/
+If you need more information about Django forms, you should read the documentation: https://docs.djangoproject.com/en/2.2/topics/forms/
 
 ## Security
 

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -161,7 +161,7 @@ Now we define the properties we were talking about: `title`, `text`, `created_da
 - `models.DateTimeField` – this is a date and time.
 - `models.ForeignKey` – this is a link to another model.
 
-We will not explain every bit of code here since it would take too much time. You should take a look at Django's documentation if you want to know more about Model fields and how to define things other than those described above (https://docs.djangoproject.com/en/2.0/ref/models/fields/#field-types).
+We will not explain every bit of code here since it would take too much time. You should take a look at Django's documentation if you want to know more about Model fields and how to define things other than those described above (https://docs.djangoproject.com/en/2.2/ref/models/fields/#field-types).
 
 What about `def publish(self):`? This is exactly the `publish` method we were talking about before. `def` means that this is a function/method and `publish` is the name of the method. You can change the name of the method if you want. The naming rule is that we use lowercase and underscores instead of spaces. For example,  a method that calculates average price could be called `calculate_average_price`.
 

--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -100,7 +100,7 @@ djangogirls
 └── requirements.txt
 ```
 
-After creating an application, we also need to tell Django that it should use it. We do that in the file `mysite/settings.py` -- open it in your code editor. We need to find `INSTALLED_APPS` and add a line containing `'blog',` just above `]`. So the final product should look like this:
+After creating an application, we also need to tell Django that it should use it. We do that in the file `mysite/settings.py` -- open it in your code editor. We need to find `INSTALLED_APPS` and add a line containing `'blog.apps.BlogConfig',` just above `]`. So the final product should look like this:
 
 {% filename %}mysite/settings.py{% endfilename %}
 ```python
@@ -111,7 +111,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'blog',
+    'blog.apps.BlogConfig',
 ]
 ```
 

--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -85,7 +85,7 @@ In `settings.py`, find the line that contains `TIME_ZONE` and modify it to choos
 TIME_ZONE = 'Europe/Berlin'
 ```
 
-A language code consist of the language, e.g. `en` for English or `de` for German, and the country code, e.g. `de` for Germany or `ch` for Switzerland. If English is not your native language, you can add this to change the default buttons and notifications from Django to be in your language. So you would have "Cancel" button translated into the language you defined here. [Django comes with a lot of prepared translations](https://docs.djangoproject.com/en/2.0/ref/settings/#language-code).
+A language code consist of the language, e.g. `en` for English or `de` for German, and the country code, e.g. `de` for Germany or `ch` for Switzerland. If English is not your native language, you can add this to change the default buttons and notifications from Django to be in your language. So you would have "Cancel" button translated into the language you defined here. [Django comes with a lot of prepared translations](https://docs.djangoproject.com/en/2.2/ref/settings/#language-code).
 
 If you want a different language, change the language code by changing the following line:
 

--- a/en/django_urls/README.md
+++ b/en/django_urls/README.md
@@ -99,4 +99,4 @@ Your console is showing an error, but don't worry – it's actually pretty usefu
 If you see a different error message, try restarting your web server. To do that, in the console window that is running the web server, stop it by pressing Ctrl+C (the Control and C keys together) and restart it by running a `python manage.py runserver` command.
 
 
-> If you want to know more about Django URLconfs, look at the official documentation: https://docs.djangoproject.com/en/2.0/topics/http/urls/
+> If you want to know more about Django URLconfs, look at the official documentation: https://docs.djangoproject.com/en/2.2/topics/http/urls/

--- a/en/django_views/README.md
+++ b/en/django_views/README.md
@@ -39,4 +39,4 @@ Another error! Read what's going on now:
 
 This shows that the server is running again, at least, but it still doesn't look right, does it? Don't worry, it's just an error page, nothing to be scared of! Just like the error messages in the console, these are actually pretty useful. You can read that the *TemplateDoesNotExist*. Let's fix this bug and create a template in the next chapter!
 
-> Learn more about Django views by reading the official documentation: https://docs.djangoproject.com/en/2.0/topics/http/views/
+> Learn more about Django views by reading the official documentation: https://docs.djangoproject.com/en/2.2/topics/http/views/

--- a/en/dynamic_data_in_templates/README.md
+++ b/en/dynamic_data_in_templates/README.md
@@ -73,4 +73,4 @@ def post_list(request):
 
 That's it! Time to go back to our template and display this QuerySet!
 
-Want to read a little bit more about QuerySets in Django? You should look here: https://docs.djangoproject.com/en/2.0/ref/models/querysets/
+Want to read a little bit more about QuerySets in Django? You should look here: https://docs.djangoproject.com/en/2.2/ref/models/querysets/

--- a/en/whats_next/README.md
+++ b/en/whats_next/README.md
@@ -14,7 +14,7 @@ Yes! There are a _lot_ of resources online for learning all kinds of programming
 
 #### Django
 - Our other book, [Django Girls Tutorial: Extensions](https://tutorial-extensions.djangogirls.org/)
-- [Django's official tutorial](https://docs.djangoproject.com/en/2.0/intro/tutorial01/)
+- [Django's official tutorial](https://docs.djangoproject.com/en/2.2/intro/tutorial01/)
 - [Getting Started With Django video lessons](http://www.gettingstartedwithdjango.com/)
 
 #### HTML, CSS and JavaScript


### PR DESCRIPTION
closes #1536

I verified the tutorial with the following combinations: 
- OSX + Python3.6.9 + Django2.2.4
- Windows10 + Python3.6.8 + Django2.2.4

It worked fine except for deployment to PythonAnywhere.
I commented on each commit where it was corrected.

Thank you.