### PR TITLE
fix capitalization of "URL"

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -14,7 +14,7 @@
 * [Django models](django_models/README.md)
 * [Django admin](django_admin/README.md)
 * [Deploy!](deploy/README.md)
-* [Django urls](django_urls/README.md)
+* [Django URLs](django_urls/README.md)
 * [Django views – time to create!](django_views/README.md)
 * [Introduction to HTML](html/README.md)
 * [Django ORM (Querysets)](django_orm/README.md)

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -326,7 +326,7 @@ def post_edit(request, pk):
     return render(request, 'blog/post_edit.html', {'form': form})
 ```
 
-This looks almost exactly the same as our `post_new` view, right? But not entirely. For one, we pass an extra `pk` parameter from urls. Next, we get the `Post` model we want to edit with `get_object_or_404(Post, pk=pk)` and then, when we create a form, we pass this post as an `instance`, both when we save the form…
+This looks almost exactly the same as our `post_new` view, right? But not entirely. For one, we pass an extra `pk` parameter from `urls`. Next, we get the `Post` model we want to edit with `get_object_or_404(Post, pk=pk)` and then, when we create a form, we pass this post as an `instance`, both when we save the form…
 
 {% filename %}blog/views.py{% endfilename %}
 ```python

--- a/en/django_urls/README.md
+++ b/en/django_urls/README.md
@@ -6,7 +6,7 @@ We're about to build our first webpage: a homepage for your blog! But first, let
 
 A URL is a web address. You can see a URL every time you visit a website – it is visible in your browser's address bar. (Yes! `127.0.0.1:8000` is a URL! And `https://djangogirls.org` is also a URL.)
 
-![Url](images/url.png)
+![URL](images/url.png)
 
 Every page on the Internet needs its own URL. This way your application knows what it should show to a user who opens that URL. In Django, we use something called `URLconf` (URL configuration). URLconf is a set of patterns that Django will try to match the requested URL to find the correct view.
 
@@ -87,7 +87,7 @@ urlpatterns = [
 ]
 ```
 
-As you can see, we're now assigning a `view` called `post_list` to the root URL. This URL pattern will match an empty string and the Django URL resolver will ignore the domain name (i.e., http://127.0.0.1:8000/) that prefixes the full url path. This pattern will tell Django that `views.post_list` is the right place to go if someone enters your website at the 'http://127.0.0.1:8000/' address.
+As you can see, we're now assigning a `view` called `post_list` to the root URL. This URL pattern will match an empty string and the Django URL resolver will ignore the domain name (i.e., http://127.0.0.1:8000/) that prefixes the full URL path. This pattern will tell Django that `views.post_list` is the right place to go if someone enters your website at the 'http://127.0.0.1:8000/' address.
 
 The last part, `name='post_list'`, is the name of the URL that will be used to identify the view. This can be the same as the name of the view but it can also be something completely different. We will be using the named URLs later in the project, so it is important to name each URL in the app. We should also try to keep the names of URLs unique and easy to remember.
 

--- a/en/extend_your_application/README.md
+++ b/en/extend_your_application/README.md
@@ -2,7 +2,7 @@
 
 # Extend your application
 
-We've already completed all the different steps necessary for the creation of our website: we know how to write a model, url, view and template. We also know how to make our website pretty.
+We've already completed all the different steps necessary for the creation of our website: we know how to write a model, URL, view and template. We also know how to make our website pretty.
 
 Time to practice!
 

--- a/en/extend_your_application/README.md
+++ b/en/extend_your_application/README.md
@@ -81,7 +81,7 @@ Do you remember what the next step is? It's adding a view!
 
 ## Add a post's detail view
 
-This time our *view* is given an extra parameter, `pk`. Our *view* needs to catch it, right? So we will define our function as `def post_detail(request, pk):`. Note that we need to use exactly the same name as the one we specified in urls (`pk`). Omitting this variable is incorrect and will result in an error!
+This time our *view* is given an extra parameter, `pk`. Our *view* needs to catch it, right? So we will define our function as `def post_detail(request, pk):`. Note that we need to use exactly the same name as the one we specified in `urls` (`pk`). Omitting this variable is incorrect and will result in an error!
 
 Now, we want to get one and only one blog post. To do this, we can use querysets, like this:
 


### PR DESCRIPTION
Changes in this pull request:

- in prose, spell "URL" all uppercase (rather than all lowercase "url" or with only initial capital "Url")
- when "url" refers to the module name (defined by `url.py`), mark it up as code (i.e. "`url`") 

I've found these occurrences with:
```bash
git grep -P '(?<!% |\.|_|`|c|/)[Uu]rl(?!s.py|patterns|resolver)' -- en/
```