### PR TITLE
fix capitalization of "GitHub"

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -8,7 +8,7 @@
   * [Virtual Environment](installation/README.md#virtual-environment)
   * [Django](installation/README.md#installing-django)
   * [Git](installation/README.md#install-git)
-  * [Github](installation/README.md#create-a-github-account)
+  * [GitHub](installation/README.md#create-a-github-account)
   * [PythonAnywhere](installation/README.md#create-a-pythonanywhere-account)
 * [Installation (chromebook)](chromebook_setup/README.md)
 * [How the Internet works](how_the_internet_works/README.md)


### PR DESCRIPTION
Changes in this pull request:

- spell "GitHub" with capital "H"