### PR TITLE
master: Fix es typos

### DIFF
--- a/es/django_forms/README.md
+++ b/es/django_forms/README.md
@@ -259,7 +259,7 @@ def post_new(request):
     return render(request, 'blog/post_edit.html', {'form': form})
 ```
 
-Veamos si funciona. Ve a la página http://127.0.0.1:8000/post/new/, añade un `title` y un `text`, guárdalo... y voilà! Se ha añadido el nuevo post al blog y somos redirigidos a la página de `post_detail`!
+Veamos si funciona. Ve a la página http://127.0.0.1:8000/post/new/, añade un `title` y un `text`, guárdalo... y voilá! Se ha añadido el nuevo post al blog y somos redirigidos a la página de `post_detail`!
 
 Puede que hayas notado que estamos indicando la fecha de publicación antes de guardar el post. Más adelante introduciremos un *botón de publicar* en el libro **Django Girls Tutorial: Extensions**.
 

--- a/es/django_orm/README.md
+++ b/es/django_orm/README.md
@@ -155,7 +155,7 @@ También puedes obtener una lista de todos los post publicados. Lo hacemos filtr
 <QuerySet []>
 ```
 
-Por desgracia, el post que hemos añadido desde la consola de Python aùn no está publicado. Pero lo podemos cambiar! Primero obtèn una instancia de la entrada que queremos publicar:
+Por desgracia, el post que hemos añadido desde la consola de Python aún no está publicado. ¡Pero lo podemos cambiar! Primero obtén una instancia de la entrada que queremos publicar:
 
 {% filename %}command-line{% endfilename %}
 

--- a/es/django_start_project/README.md
+++ b/es/django_start_project/README.md
@@ -54,7 +54,7 @@ En Windows debes ejecutar el siguiente comando. **(No olvides incluir el punto `
     └───requirements.txt
 
 
-> **Nota**: en tu estructura de directorios, tambièn veràs el directorio `venv` que creamos anteriormente.
+> **Nota**: en tu estructura de directorios, también verás el directorio `venv` que creamos anteriormente.
 
 `manage.py` es un script que ayuda con la administración del sitio. Con él podremos iniciar un servidor web en nuestro ordenador sin necesidad de instalar nada más, entre otras cosas.
 
@@ -68,7 +68,7 @@ Por ahora vamos a ignorar el resto de archivos porque no los vamos a cambiar. ¡
 
 Vamos a hacer algunos cambios en `mysite/settings.py`. Abre el archivo usando el editor de código que has instalado anteriormente.
 
-**Nota**: Ten en cuenta que `settings.py` es un archivo normal, como cualquier otro. Puedes abrirlo con el editor de texto, usando "file -> open" en el menu de acciones. Esto te deberìa llevar a la tìpica ventana donde puedes buscar el archivo `settings.py` y seleccionarlo. Como alternativa, puedes abrir el archivo haciendo click derecho en la carpeta djangogirls en tu escritorio. Luego, selecciona tu editor de texto en la lista. Elegir el editor es importante puesto que puede que tengas otros programas que pueden abrir el archivo pero que no te dejaran editarlo.
+**Nota**: Ten en cuenta que `settings.py` es un archivo normal, como cualquier otro. Puedes abrirlo con el editor de texto, usando "file -> open" en el menu de acciones. Esto te debería llevar a la típica ventana donde puedes buscar el archivo `settings.py` y seleccionarlo. Como alternativa, puedes abrir el archivo haciendo click derecho en la carpeta djangogirls en tu escritorio. Luego, selecciona tu editor de texto en la lista. Elegir el editor es importante puesto que puede que tengas otros programas que pueden abrir el archivo pero que no te dejaran editarlo.
 
 Sería bueno tener el horario correcto en nuestro sitio web. Ve a [lista de Wikipedia de las zonas horarias](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) y copia tu zona horaria (TZ) (e.g. `Europa/Berlín`).
 
@@ -99,7 +99,7 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 ```
 
-Cuando `DEBUG` es `True` y `ALLOWED_HOST` esta vacìo, el host es validado contra `['localhost', '127,0.0.1', '[::1]']`. Una vez despleguemos nuestra aplicaciòn este no sera el mismo que nuestro nombre de host en PythonAnywhere asi que cambiaremos la siguiente opciòn:
+Cuando `DEBUG` es `True` y `ALLOWED_HOST` esta vacío, el host es validado contra `['localhost', '127,0.0.1', '[::1]']`. Una vez despleguemos nuestra aplicación este no sera el mismo que nuestro nombre de host en PythonAnywhere asi que cambiaremos la siguiente opción:
 
 {% filename %}mysite/settings.py{% endfilename %}
 
@@ -184,7 +184,7 @@ Ahora todo lo que tienes que hacer es comprobar que tu sitio se esté ejecutando
     http://127.0.0.1:8000/
 
 
-Si estàs usando un Chromebook, siempre visitaras tu servidor de pruebas accediendo a:
+Si estás usando un Chromebook, siempre visitaras tu servidor de pruebas accediendo a:
 
 {% filename %}browser{% endfilename %}
 
@@ -195,9 +195,9 @@ Si estàs usando un Chromebook, siempre visitaras tu servidor de pruebas accedie
 
 ![¡La instalación ha funcionado!](images/install_worked.png)
 
-Mientras el servidor se este ejecutando, no podràs ejecutar comandos adicionales. La terminal aceptarà texto pero no ejecutara ningùn comando. Esto sucede porque el servidor se ejecuta continuamente para recibir solicitudes.
+Mientras el servidor se este ejecutando, no podrás ejecutar comandos adicionales. La terminal aceptará texto pero no ejecutara ningún comando. Esto sucede porque el servidor se ejecuta continuamente para recibir solicitudes.
 
-> Miramos como funcionan los servidores web en el capìtulo **Còmo funciona el internet**.
+> Miramos como funcionan los servidores web en el capítulo **Cómo funciona el internet**.
 
 Recuerda, para escribir comandos mientras el servidor web esta funcionando, abre una nueva terminal y activa el virtualenv. Para parar el servidor web, ve a la ventana donde se esté ejecutando y pulsa CTRL+C, las teclas Control y C a la vez ( en Windows puede que tengas que pulsar Ctrl+Break).
 

--- a/es/django_urls/README.md
+++ b/es/django_urls/README.md
@@ -4,7 +4,7 @@ Estamos a punto de construir nuestra primera página web: ¡una página de inici
 
 ## ¿Qué es una URL?
 
-Una URL es una dirección de la web. Puedes ver una URL cada vez que visitas una página. Se ve en la barra de direcciones del navegador. (Sì! ¡`127.0.0.1:8000` es una URL! Y `https://djangogirls.org` también es una URL.)
+Una URL es una dirección de la web. Puedes ver una URL cada vez que visitas una página. Se ve en la barra de direcciones del navegador. (Sí! ¡`127.0.0.1:8000` es una URL! Y `https://djangogirls.org` también es una URL.)
 
 ![URL](images/url.png)
 
@@ -98,6 +98,6 @@ Si tratas de visitar http://127.0.0.1:8000/ ahora, encontrarás un mensaje de er
 
 ![Error](images/error1.png)
 
-La consola esta mostrando un error, pero no te preocupes - de hecho es muy ùtil: està diciendote que **no existe el atributo 'post_list'**. Ese es el nombre del *view* que Django está tratando de encontrar y usar, pero aun no lo hemos creado. En esta etapa tu `/admin/` tampoco funcionarà. No te preocupes, ya llegaremos a eso. Si ves un error diferente, intenta reiniciar el servidor web. Para ello, en la consola en la que se está ejecutando el servidor web, páralo pulsando Ctrl+C (las teclas Control y C a la vez) y reinícialo ejecutando el comando `python manage.py runserver`.
+La consola esta mostrando un error, pero no te preocupes - de hecho es muy útil: está diciendote que **no existe el atributo 'post_list'**. Ese es el nombre del *view* que Django está tratando de encontrar y usar, pero aun no lo hemos creado. En esta etapa tu `/admin/` tampoco funcionará. No te preocupes, ya llegaremos a eso. Si ves un error diferente, intenta reiniciar el servidor web. Para ello, en la consola en la que se está ejecutando el servidor web, páralo pulsando Ctrl+C (las teclas Control y C a la vez) y reinícialo ejecutando el comando `python manage.py runserver`.
 
 > Si quieres saber más sobre Django URLconfs, mira la documentación oficial: https://docs.djangoproject.com/en/2.0/topics/http/urls/

--- a/es/django_views/README.md
+++ b/es/django_views/README.md
@@ -20,7 +20,7 @@ from django.shortcuts import render
 
 No hay demasiadas cosas aquí todavía.
 
-Recuerda que las lineas que comienzan con `#` son comentarios - significa que Python no las ejecutarà.
+Recuerda que las lineas que comienzan con `#` son comentarios - significa que Python no las ejecutará.
 
 Creemos una *vista (view)* como sugiere el comentario. Añade la siguiente mini-vista por debajo:
 

--- a/es/whats_next/README.md
+++ b/es/whats_next/README.md
@@ -12,7 +12,7 @@ Después de eso, asegúrate de seguir a Django Girls en [Facebook](http://facebo
 
 ¡Claro! En primer lugar, sigue adelante y prueba nuestro otro libro llamado [Django Girls Turorial: Extensions](https://tutorial-extensions.djangogirls.org/).
 
-Luego, puedes intentar los recursos listados a continuaciòn. ¡Todos son muy recomendados!
+Luego, puedes intentar los recursos listados a continuación. ¡Todos son muy recomendados!
 
 - [Django's official tutorial (Tutorial oficial de Django)](https://docs.djangoproject.com/en/2.0/intro/tutorial01/)
 - [New Coder turorials (Tutoriales de "New Coder")](http://newcoder.io/tutorials/)
@@ -21,5 +21,5 @@ Luego, puedes intentar los recursos listados a continuaciòn. ¡Todos son muy re
 - [Django Carrots tutorial (Tutorial de Django de "Carrots")](https://github.com/ggcarrots/django-carrots)
 - [Learn Python The Hard Way book (Libro Aprende Python a las Malas)](http://learnpythonthehardway.org/book/)
 - [Getting Started With Django video lessons (Lecciones de video Empezando con Django)](http://www.gettingstartedwithdjango.com/)
-- [Two Scoops of Django 1.11: Best Practices for Django Web Framework book (Libro Dos Cucharadas de Django 1.11: mejores pràcticas para Django Web Framework)](https://www.twoscoopspress.com/products/two-scoops-of-django-1-11)
-- [Hello Web App: Learn How to Build a Web App (Hola aplicaciòn web: Aprende como construir una aplicaciòn web)](https://hellowebapp.com/) - tambièn puedes solicitar un eBook gratis contactando con la autora Tracy Osborn en <tracy@limedaring.com>
+- [Two Scoops of Django 1.11: Best Practices for Django Web Framework book (Libro Dos Cucharadas de Django 1.11: mejores prácticas para Django Web Framework)](https://www.twoscoopspress.com/products/two-scoops-of-django-1-11)
+- [Hello Web App: Learn How to Build a Web App (Hola aplicación web: Aprende como construir una aplicación web)](https://hellowebapp.com/) - también puedes solicitar un eBook gratis contactando con la autora Tracy Osborn en <tracy@limedaring.com>


### PR DESCRIPTION
Changes in this pull request:

- add some missing "¡"
- replace "à", "è", "ì", "ò", "ù" by "á", "é", "í", "ó", "ú"

in the es translation