### PR TITLE
fix Codecademy CSS/HTML course link broken, update for freeCodeCamp link (resolves #1572)

### DIFF
--- a/en/css/README.md
+++ b/en/css/README.md
@@ -297,7 +297,7 @@ Look at the code we just pasted to find the places where we added classes in the
 
 Don't be afraid to tinker with this CSS a little bit and try to change some things. Playing with the CSS can help you understand what the different things are doing. If you break something, don't worry – you can always undo it!
 
-We really recommend taking this free online [Codeacademy HTML & CSS course](https://www.codecademy.com/tracks/web). It can help you learn all about making your websites prettier with CSS.
+We really recommend taking this free online [freeCodeCamp - Basic HTML & HTML5](https://learn.freecodecamp.org/). It can help you learn all about making your websites prettier with CSS.
 
 Ready for the next chapter?! :)
 

--- a/en/css/README.md
+++ b/en/css/README.md
@@ -297,7 +297,7 @@ Look at the code we just pasted to find the places where we added classes in the
 
 Don't be afraid to tinker with this CSS a little bit and try to change some things. Playing with the CSS can help you understand what the different things are doing. If you break something, don't worry – you can always undo it!
 
-We really recommend taking this free online [freeCodeCamp - Basic HTML & HTML5](https://learn.freecodecamp.org/). It can help you learn all about making your websites prettier with CSS.
+We really recommend taking this free online [freeCodeCamp - Basic HTML & HTML5 course](https://learn.freecodecamp.org/). It can help you learn all about making your websites prettier with CSS.
 
 Ready for the next chapter?! :)
 

--- a/en/css/README.md
+++ b/en/css/README.md
@@ -297,7 +297,7 @@ Look at the code we just pasted to find the places where we added classes in the
 
 Don't be afraid to tinker with this CSS a little bit and try to change some things. Playing with the CSS can help you understand what the different things are doing. If you break something, don't worry – you can always undo it!
 
-We really recommend taking this free online [freeCodeCamp - Basic HTML & HTML5 course](https://learn.freecodecamp.org/). It can help you learn all about making your websites prettier with CSS.
+We really recommend taking the free online courses "Basic HTML & HTML5" and "Basic CSS" on [freeCodeCamp](https://learn.freecodecamp.org/). They can help you learn all about making your websites prettier with HTML and CSS.
 
 Ready for the next chapter?! :)
 


### PR DESCRIPTION
The css section of the English tutorial had an external link to codeacademy, but it is no longer free. To fix the bug, I modified the link to freeCodeCamp which has a free HTML and CSS course.
