### PR TITLE
Indicate that directory venv is also there when showing where to put requirements.txt

### DIFF
--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -183,9 +183,10 @@ First create a `requirements.txt` file inside of the `djangogirls/` folder, usin
 
 ```
 djangogirls
+├── myvenv
+│   └── ...
 └───requirements.txt
 ```
-> **Note**: in your directory structure, you will also see your `venv` directory.
 
 In your `djangogirls/requirements.txt` file you should add the following text:
 

--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -185,6 +185,7 @@ First create a `requirements.txt` file inside of the `djangogirls/` folder, usin
 djangogirls
 └───requirements.txt
 ```
+> **Note**: in your directory structure, you will also see your `venv` directory.
 
 In your `djangogirls/requirements.txt` file you should add the following text:
 


### PR DESCRIPTION
I added a note about the directory structure in the description of `requirements.txt` .
This is because beginners are confused because the description of the `venv` directory is not written.