### PR TITLE
rephrase sentence to fix "page header" ambiguity

### DIFF
--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -44,7 +44,7 @@ So once again we will create a link to the page, a URL, a view and a template.
 
 ## Link to a page with the form
 
-It's time to open `blog/templates/blog/base.html` in the code editor. We will add a link in `div` named `page-header`:
+It's time to open `blog/templates/blog/base.html` in the code editor. In `div` named `page-header`, we will add a link:
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -44,7 +44,7 @@ So once again we will create a link to the page, a URL, a view and a template.
 
 ## Link to a page with the form
 
-It's time to open `blog/templates/blog/base.html` in the code editor. In `div` named `page-header`, we will add a link:
+It's time to open `blog/templates/blog/base.html` in the code editor. In the `div` named `page-header`, we will add a link:
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html


### PR DESCRIPTION
rephrase sentence to make clear which element the name `page-header` refers to. (It's the `div`, not the link.)

This should fix the ambiguity noticed in PR #1589, which has been reverted with PR #1590.

See https://github.com/DjangoGirls/tutorial/pull/1589#pullrequestreview-300581137

/cc @PierreGuilmin