### PR TITLE
Remove urls.py from startapp blog file listing (#1535)

### DIFF
--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -88,7 +88,6 @@ djangogirls
 │   │   └── __init__.py
 │   ├── models.py
 │   ├── tests.py
-|   ├── urls.py
 │   └── views.py
 ├── db.sqlite3
 ├── manage.py


### PR DESCRIPTION
Fixes #1535. `python manage.py startapp blog` doesn’t create this file: https://stackoverflow.com/questions/45002225/why-isnt-urls-py-generated-with-django-admin-startapp-mysite