### PR TITLE
list dir myvenv/ in file trees and fix nested tree display

### DIFF
--- a/en/django_models/README.md
+++ b/en/django_models/README.md
@@ -81,9 +81,9 @@ You will notice that a new `blog` directory is created and it contains a number 
 ```
 djangogirls
 ├── blog
-│   ├── __init__.py
 │   ├── admin.py
 │   ├── apps.py
+│   ├── __init__.py
 │   ├── migrations
 │   │   └── __init__.py
 │   ├── models.py
@@ -96,7 +96,10 @@ djangogirls
 │   ├── settings.py
 │   ├── urls.py
 │   └── wsgi.py
+├── myvenv
+│   └── ...
 └── requirements.txt
+
 ```
 
 After creating an application, we also need to tell Django that it should use it. We do that in the file `mysite/settings.py` -- open it in your code editor. We need to find `INSTALLED_APPS` and add a line containing `'blog.apps.BlogConfig',` just above `]`. So the final product should look like this:

--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -51,13 +51,15 @@ The `(myvenv) C:\Users\Name\djangogirls>` part shown here is just example of the
 
 ```
 djangogirls
-├───manage.py
-├───mysite
-│        settings.py
-│        urls.py
-│        wsgi.py
-│        __init__.py
-└───requirements.txt
+├── manage.py
+├── mysite
+│   ├── __init__.py
+│   ├── settings.py
+│   ├── urls.py
+│   └── wsgi.py
+├── myvenv
+│   └── ...
+└── requirements.txt
 ```
 > **Note**: in your directory structure, you will also see your `venv` directory that we created before.
 


### PR DESCRIPTION
List dir `myvenv/` in file trees and fix nested tree display.

Also, order entries the way [`tree`](https://en.wikipedia.org/wiki/Tree_(command)) does.

The new version of the listings were created by running
```bash
tree -L 3 djangogirls -I *.pyc -I __pycache__
```
from the directory containing the `djangogirls` directory and then manually replacing the subtree below `myvenv` with just `...` and removing the line at the end with the number-of-files statistic.