### PR TITLE
Change `git status` output to reflect no previous commit

### DIFF
--- a/cs/deploy/README.md
+++ b/cs/deploy/README.md
@@ -59,7 +59,7 @@ Je vhodné použít příkaz `git status` před použitím příkazu `git add`, 
 $ git status
  On branch master
 
- Initial commit
+ No commits yet
 
 Untracked files:
    (use "git add <file>..." to include in what will be committed)

--- a/es/deploy/README.md
+++ b/es/deploy/README.md
@@ -58,7 +58,7 @@ Te recomendamos utilizar el comando `git status` antes de `git add` o en cualqui
     $ git status
     On branch master
     
-    Initial commit
+    No commits yet
     
     Untracked files:
       (use "git add <file>..." to include in what will be committed)

--- a/hu/deploy/README.md
+++ b/hu/deploy/README.md
@@ -60,7 +60,7 @@ Jó ötlet a `git status` parancs használata még a `git add` előtt, valamint 
     $ git status
     On branch master
     
-    Initial commit
+    No commits yet
     
     Untracked files:
       (use "git add <file>..." to include in what will be committed)

--- a/it/deploy/README.md
+++ b/it/deploy/README.md
@@ -57,7 +57,7 @@ E salvalo come `.gitignore` all'interno della cartella "djangogirls".
     $ git status
     On branch master
     
-    Initial commit
+    No commits yet
     
     Untracked files:
       (use "git add <file>..." to include in what will be committed)

--- a/ko/deploy/README.md
+++ b/ko/deploy/README.md
@@ -58,7 +58,7 @@ db.sqlite3
 $ git status
 On branch master
 
-Initial commit
+No commits yet
 
 Untracked files:
   (use "git add <file>..." to include in what will be committed)

--- a/pl/deploy/README.md
+++ b/pl/deploy/README.md
@@ -58,7 +58,7 @@ Dobrym nawykiem jest wpisywanie polecenia `git status` zanim wpiszesz `git add` 
     $ git status
     On branch master
     
-    Initial commit
+    No commits yet
     
     Untracked files:
       (use "git add <file>..." to include in what will be committed)

--- a/pt/deploy/README.md
+++ b/pt/deploy/README.md
@@ -58,7 +58,7 @@ E salve-o como `.gitignore` na pasta "djangogirls".
     $ git status
     On branch master
     
-    Initial commit
+    No commits yet
     
     Untracked files:
       (use "git add <file>..." to include in what will be committed)

--- a/ru/deploy/README.md
+++ b/ru/deploy/README.md
@@ -62,7 +62,7 @@ db.sqlite3
 $ git status
 On branch master
 
-Initial commit
+No commits yet
 
 Untracked files:
   (use "git add <file>..." to include in what will be committed)

--- a/tr/deploy/README.md
+++ b/tr/deploy/README.md
@@ -59,7 +59,7 @@ Ve onu `.gitignore` ismi ile "djangogirls" dizinine kaydedin.
     $ git status
     On branch master
     
-    Initial commit
+    No commits yet
     
     Untracked files:
       (use "git add <file>..." to include in what will be committed)

--- a/uk/deploy/README.md
+++ b/uk/deploy/README.md
@@ -55,7 +55,7 @@ db.sqlite3
     $ git status
     On branch master
 
-    Initial commit
+    No commits yet
 
     Untracked files:
       (use "git add <file>..." to include in what will be committed)

--- a/zh/deploy/README.md
+++ b/zh/deploy/README.md
@@ -56,7 +56,7 @@ Git会追踪这个目录下所有文件和文件夹的更改，但是有一些�
     $ git status
     On branch master
     
-    Initial commit
+    No commits yet
     
     Untracked files:
       (use "git add <file>..." to include in what will be committed)


### PR DESCRIPTION
The output from git is given as though a first commit has already been made. This corrects it to show that no commits have been made yet.