### PR TITLE
separate blockquote blocks

### DIFF
--- a/en/django_installation/instructions.md
+++ b/en/django_installation/instructions.md
@@ -127,6 +127,8 @@ C:\Users\Name\djangogirls> myvenv\Scripts\activate
 >     The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at http://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy? [Y] Yes  [A] Yes to All  [N] No  [L] No to All  [S] Suspend  [?] Help (default is "N"): A
 >```
 
+<!-- (This comment separates the two blockquote blocks, so that GitBook and Crowdin don't merge them into a single block.) -->
+
 > __NOTE:__ For users of the popular editor VS Code, which come with an integrated terminal based off windows powershell, if you wish to stick with the integrated terminal, you may run the following command to activate your virtual environment:
 >
 >```


### PR DESCRIPTION
Add an HTML comment to separate the two blockquote blocks, so that GitBook and Crowdin don't merge them into a single block.

See https://github.com/DjangoGirls/tutorial/pull/1603#discussion_r336930974