### PR TITLE
Replace "Let's type" with "Enter"

### DIFF
--- a/en/extend_your_application/README.md
+++ b/en/extend_your_application/README.md
@@ -134,7 +134,7 @@ Oh no! Another error! But we already know how to deal with it, right? We need to
 
 We will create a file in `blog/templates/blog` called `post_detail.html`, and open it in the code editor.
 
-Let's type the following code:
+Enter the following code:
 
 {% filename %}blog/templates/blog/post_detail.html{% endfilename %}
 ```html


### PR DESCRIPTION
Changes in this pull request:

- Replace "Let's type" from #1606 with "Enter" as it some participants may want to copy-paste it instead of typing all that manually, and that's OK.