### PR TITLE
[Spanish] [CSS] Fix selector of headings when changing font family

### DIFF
--- a/es/css/README.md
+++ b/es/css/README.md
@@ -169,7 +169,7 @@ Encuentra el bloque de declaración (el código entre las llaves `{` y `}`) `h1 
 {% filename %}blog/static/css/blog.css{% endfilename %}
 
 ```css
-h1 a {
+h1 a, h2 a {
     color: #FCA205;
     font-family: 'Lobster';
 }


### PR DESCRIPTION
With previous snippet the result did not match the screenshot.

Also, the text before mentions modifying a CSS snippet previously implemented as:

```css
h1 a, h2 a {
     color: #C25100;
}
```