### PR TITLE
Be more explicit about next steps with QuerySet

### DIFF
--- a/en/dynamic_data_in_templates/README.md
+++ b/en/dynamic_data_in_templates/README.md
@@ -52,7 +52,9 @@ def post_list(request):
     return render(request, 'blog/post_list.html', {})
 ```
 
-The last missing part is passing the `posts` QuerySet to the template context. Don't worry – we will cover how to display it in a later chapter.
+To display our QuerySet on our blog's post list, we have two things left to do:
+1. Pass the `posts` QuerySet to the template context, by changing the `render` function call. We'll do this now.
+2. Modify the template to display the `posts` QuerySet. We'll cover this in a later chapter.
 
 Please note that we create a *variable* for our QuerySet: `posts`. Treat this as the name of our QuerySet. From now on we can refer to it by this name.
 


### PR DESCRIPTION
When I was reading through the tutorial, I got to this section and read:

```
The last missing part is passing the `posts` QuerySet to the template context.
Don't worry – we will cover how to display it in a later chapter.
```

On a first read, this confused me -- I thought in both sentences we were talking about the same action (passing `posts` into the `render` call and displaying it in the template); making it additionally confusing that we were doing _some_ work in this chapter about passing in posts.

I wondered whether the "next chapter" sentence was even necessary, and found this in the commit logs: https://github.com/DjangoGirls/tutorial/commit/8db3c9174e1754bbaaaa07535d4fe35ffa98713a.

Noting that the ordering of the sentences had confused participants, and they apparently wanted to hear that they were going to cover displaying `posts` before an explanation of what `posts` was, I'm inferring that at least some have notice that this is missing and want to hear what the
next steps are.

So I tried to break up that sentence into two clearly separate steps, explaining what we'll do next and what we'll do later.