### PR TITLE
- Add caveat about automatic changes to settings.py and git conflict

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -172,6 +172,15 @@ As you watch that running, you'll be able to see what it's doing:
 
 On PythonAnywhere all those steps are automated, but they're the same steps you would have to go through with any other server provider.
 
+**NOTE:** Because the above changes the contents of `settings.py`,
+PythonAnywhere's `settings.py` will now be different from the copy you
+have on both your local computer and on GitHub. If you need to change
+`settings.py` after this step, you may want to ask a coach for help,
+in order to synchronize your copies with the deployed copy on
+PythonAnywhere before proceeding. In addition, after such a change,
+you may need to reload your server. (Reloading is covered later in
+this tutorial.)
+
 The main thing to notice right now is that your database on PythonAnywhere is actually totally separate from your database on your own computer, so it can have different posts and admin accounts. As a result, just as we did on your own computer, we need to initialize the admin account with `createsuperuser`. PythonAnywhere has automatically activated your virtualenv for you, so all you need to do is run:
 
 {% filename %}PythonAnywhere command-line{% endfilename %}

--- a/en/django_orm/README.md
+++ b/en/django_orm/README.md
@@ -62,7 +62,7 @@ This is a list of the posts we created earlier! We created these posts using the
 
 ### Create object
 
-This is how you create a new Post object in database:
+This is how you create a new Post object in the database:
 
 {% filename %}command-line{% endfilename %}
 ```python


### PR DESCRIPTION
Because I missed the leading "." before "pythonanywhere.com" in **settings.py** my `ALLOWED_HOSTS` read:

    ALLOWED_HOSTS = ["127.0.0.1", "pythonanywhere.com"]

This meant that the testing on the local development machine worked, but the deployed copy did not. I quickly realized the mistake, but since `pa_autoconfigure_django.py` had changed the "production" copy of `settings.py`, it was out of sync with the both my development machine and the hosted git repository.

Missing the leading "." seems like a potentially common mistake.  So maybe that's where the tutorial should change, calling people's attention to that, instead.