### PR TITLE
Add link to Creative Commons in Japanese

### DIFF
--- a/ja/README.md
+++ b/ja/README.md
@@ -2,7 +2,7 @@
 
 [![Gitter](https://badges.gitter.im/DjangoGirls/tutorial.svg)](https://gitter.im/DjangoGirls/tutorial)
 
-> これは、Creative Commons Attribution-ShareAlike 4.0 International License のライセンスの下で提供しています。ライセンスについてはこちらをご確認ください。 https://creativecommons.org/licenses/by-sa/4.0/
+> これは、Creative Commons Attribution-ShareAlike 4.0 International License のライセンスの下で提供しています。ライセンスについてはこちらをご確認ください。 https://creativecommons.org/licenses/by-sa/4.0/ [日本語版](https://creativecommons.org/licenses/by-sa/4.0/deed.ja)
 
 ## ウェルカム！
 


### PR DESCRIPTION
Keep existing link.

Changes in this pull request:

- Add link to Creative Commons in Japanese at  ja/README.md.
