### PR TITLE
write "installation steps" in lowercase

### DIFF
--- a/en/chromebook_setup/README.md
+++ b/en/chromebook_setup/README.md
@@ -1,5 +1,5 @@
 # Chromebook setup
 
-> **Note** If you already worked through the Installation steps, no need to do this again – you can skip straight ahead to [Introduction to Python](../python_introduction/README.md).
+> **Note** If you already worked through the installation steps, no need to do this again – you can skip straight ahead to [Introduction to Python](../python_introduction/README.md).
 
 {% include "/chromebook_setup/instructions.md" %}

--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -12,7 +12,7 @@ These three places will be important to you.  Your local computer will be the pl
 
 # Git
 
-> **Note** If you already did the Installation steps, there's no need to do this again – you can skip to the next section and start creating your Git repository.
+> **Note** If you already did the installation steps, there's no need to do this again – you can skip to the next section and start creating your Git repository.
 
 {% include "/deploy/install_git.md" %}
 

--- a/en/django_installation/README.md
+++ b/en/django_installation/README.md
@@ -2,6 +2,6 @@
 
 > **Note** If you're using a Chromebook, skip this chapter and make sure you follow the [Chromebook Setup](../chromebook_setup/README.md) instructions.
 
-> **Note** If you already worked through the Installation steps then you've already done this – you can go straight to the next chapter!
+> **Note** If you already worked through the installation steps then you've already done this – you can go straight to the next chapter!
 
 {% include "/django_installation/instructions.md" %}

--- a/en/python_installation/README.md
+++ b/en/python_installation/README.md
@@ -10,7 +10,7 @@ Python originated in the late 1980s and its main goal is to be readable by human
 
 > **Note** If you're using a Chromebook, skip this chapter and make sure you follow the [Chromebook Setup](../chromebook_setup/README.md) instructions.
 
-> **Note** If you already worked through the Installation steps, there's no need to do this again – you can skip straight ahead to the next chapter!
+> **Note** If you already worked through the installation steps, there's no need to do this again – you can skip straight ahead to the next chapter!
 
 {% include "/python_installation/instructions.md" %}
 


### PR DESCRIPTION
Changes in this pull request:

- write "installation steps" in lowercase (But keep "Installation chapter" with an upper case "I", as it refers to a
title.)