### PR TITLE
ignore only top-level static/ dir, not every one

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -49,8 +49,8 @@ venv/
 # Database
 db.sqlite3
 
-# Static folder
-static/
+# Static folder at project root
+/static/
 
 # macOS
 ._*


### PR DESCRIPTION
See https://github.com/DjangoGirls/tutorial/commit/be2f0b0f306dd82d79a6e6f0516a09cca90e560d#r45123764 (Thanks for pointing this out, @nikhiljohn10)

Changes in this pull request:

- limit gitignore entry for directories called `static/` to the one at the project root, i.e., don't exclude directories called `static` elsewhere in the project from being tracked by Git

These non-toplevel directories are needed to store static files in the source tree, see [Where to put static files for Django](https://tutorial.djangogirls.org/en/css/#where-to-put-static-files-for-django) in our CSS chapter. The top-level folder corresponds to the `STATIC_ROOT` setting we set [when setting up the Django project and its settings](https://tutorial.djangogirls.org/en/django_start_project/#changing-settings). It's filled with copies of the contents of the non-toplevel static files when `python manage.py collectstatic` is run [by the user when re-deploying](https://tutorial.djangogirls.org/en/extend_your_application/#updating-the-static-files-on-the-server) or probably by the `pa_autoconfigure_django.py` script [during initial deployment](https://tutorial.djangogirls.org/en/deploy/#configuring-our-site-on-pythonanywhere). (IIRC, we never do that locally during the tutorial, but some participants might do so by mistake or after the tutorial by purpose, or they might make Git commits on the server side for some reason, so still keeping the top-level `static/` dir ignored makes sense.)