### PR TITLE
fix grammar: "as follow" -> "as follows", add articles, minor rephrasing

### DIFF
--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -48,7 +48,7 @@ Before we add the link, we need some icons to use as buttons for the link. For t
 
 > Note: To download the SVG image, open the context menu on the link (usually by right-clicking on it) and select "Save link as". In the dialog asking you where to save the file, navigate to the `djangogirls` directory of your Django project, and within that to subdirectory `blog/templates/blog/icons/`, and save the file there.
 
-It's time to open `blog/templates/blog/base.html` in the code editor. Now we can use this icon file inside the base template as follow. In the `div` tag inside `header` section, we will add a link before `h1` tag:
+It's time to open `blog/templates/blog/base.html` in the code editor. Now we can use this icon file inside the base template as follows. In the `div` tag inside `header` section, we will add a link before `h1` tag:
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html

--- a/en/html/README.md
+++ b/en/html/README.md
@@ -152,7 +152,7 @@ Here's an example of a full template, copy and paste it into `blog/templates/blo
 We've created one `header` section and two `article` section here.
 
 - The `header` element contains the title of our blog – it's a heading and a link
-- Another two `article` elements contain our blog posts with a published date in `time` element, `h2` with a post title that is clickable and a `p` (paragraph) of text for our blog post.
+- Another two `article` elements contain our blog posts with a published date in a `time` element, a `h2` with a post title that is clickable and a `p` (paragraph) of text for our blog post.
 
 It gives us this effect:
 

--- a/en/html/README.md
+++ b/en/html/README.md
@@ -152,7 +152,7 @@ Here's an example of a full template, copy and paste it into `blog/templates/blo
 We've created one `header` section and two `article` section here.
 
 - The `header` element contains the title of our blog – it's a heading and a link
-- Another two `article` elements contain our blog posts with a published date in a `time` element, a `h2` element with a post title that is clickable and a `p` (paragraph) element of text for our blog post.
+- Another two `article` elements contain our blog posts with a published date in a `time` element, a `h2` element with a post title that is clickable and a `p` (paragraph) element for text of our blog post.
 
 It gives us this effect:
 

--- a/en/html/README.md
+++ b/en/html/README.md
@@ -152,7 +152,7 @@ Here's an example of a full template, copy and paste it into `blog/templates/blo
 We've created one `header` section and two `article` section here.
 
 - The `header` element contains the title of our blog – it's a heading and a link
-- Another two `article` elements contain our blog posts with a published date in a `time` element, a `h2` with a post title that is clickable and a `p` (paragraph) of text for our blog post.
+- Another two `article` elements contain our blog posts with a published date in a `time` element, a `h2` element with a post title that is clickable and a `p` (paragraph) element of text for our blog post.
 
 It gives us this effect:
 


### PR DESCRIPTION
Changes in this pull request:

- replace "as follow" by "as follows"
- add indefinite articles ("a") at some places
- specify that the stuff mentioned at https://github.com/DjangoGirls/tutorial/blob/11e71b5b351292f54648b615712ebea3ebc77b9a/en/html/README.md#L155 indeed are (HTML) _"elements"_
- minor rephrasing (11e71b5) for more natural language flow

(I noticed this when trying to translate the changes from #1681 to German.)