### PR TITLE
fix logic: These can't be "another two" article elements

### DIFF
--- a/en/html/README.md
+++ b/en/html/README.md
@@ -152,7 +152,7 @@ Here's an example of a full template, copy and paste it into `blog/templates/blo
 We've created one `header` section and two `article` section here.
 
 - The `header` element contains the title of our blog – it's a heading and a link
-- Another two `article` elements contain our blog posts with a published date in `time` element, `h2` with a post title that is clickable and a `p` (paragraph) of text for our blog post.
+- The two `article` elements contain our blog posts with a published date in `time` element, `h2` with a post title that is clickable and a `p` (paragraph) of text for our blog post.
 
 It gives us this effect:
 


### PR DESCRIPTION
These can't be "another two" article elements if no other article elements have been mentioned, yet. (Previously they were `div` elements and the now-`header` element preceding them was then also a `div`. But since #1681 not anymore.)

Changes in this pull request:

- replace "**Another** two `article` elements" with "**The** two `article` elements"
