### PR TITLE
use term "element" to refer to HTML elements as a whole

### DIFF
--- a/en/css/README.md
+++ b/en/css/README.md
@@ -85,7 +85,7 @@ h1 a, h2 a {
 `h1 a` is a CSS Selector. This means we're applying our styles to any `a` element inside of an `h1` element; the `h2 a` selector does the same thing for `h2` elements. So when we have something like `<h1><a href="">link</a></h1>`, the `h1 a` style will apply. In this case, we're telling it to change its color to `#C25100`, which is a dark orange. Or you can put your own color here, but make sure it has good contrast against a white background!
 
 In a CSS file we determine styles for elements in the HTML file. The first way we identify elements is with the element name. You might remember these as tags from the HTML section. Things like `a`, `h1`, and `body` are all examples of element names.
-We also identify elements by the attribute `class` or the attribute `id`. Class and id are names you give the element by yourself. Classes define groups of elements, and ids point to specific elements. For example, you could identify the following tag by using the tag name `a`, the class `external_link`, or the id `link_to_wiki_page`:
+We also identify elements by the attribute `class` or the attribute `id`. Class and id are names you give the element by yourself. Classes define groups of elements, and ids point to specific elements. For example, you could identify the following element by using the element name `a`, the class `external_link`, or the id `link_to_wiki_page`:
 
 ```html
 <a href="https://en.wikipedia.org/wiki/Django" class="external_link" id="link_to_wiki_page">

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -48,7 +48,7 @@ Before we add the link, we need some icons to use as buttons for the link. For t
 
 > Note: To download the SVG image, open the context menu on the link (usually by right-clicking on it) and select "Save link as". In the dialog asking you where to save the file, navigate to the `djangogirls` directory of your Django project, and within that to subdirectory `blog/templates/blog/icons/`, and save the file there.
 
-It's time to open `blog/templates/blog/base.html` in the code editor. Now we can use this icon file inside the base template as follow. In the `div` element inside `header` section, we will add a link before `h1` element:
+It's time to open `blog/templates/blog/base.html` in the code editor. Now we can use this icon file inside the base template as follow. In the `div` element inside `header` section, we will add a link before the `h1` element:
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -48,7 +48,7 @@ Before we add the link, we need some icons to use as buttons for the link. For t
 
 > Note: To download the SVG image, open the context menu on the link (usually by right-clicking on it) and select "Save link as". In the dialog asking you where to save the file, navigate to the `djangogirls` directory of your Django project, and within that to subdirectory `blog/templates/blog/icons/`, and save the file there.
 
-It's time to open `blog/templates/blog/base.html` in the code editor. Now we can use this icon file inside the base template as follow. In the `div` tag inside `header` section, we will add a link before `h1` tag:
+It's time to open `blog/templates/blog/base.html` in the code editor. Now we can use this icon file inside the base template as follow. In the `div` element inside `header` section, we will add a link before `h1` element:
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html
@@ -147,7 +147,7 @@ To create a new `Post` form, we need to call `PostForm()` and pass it to the tem
 We need to create a file `post_edit.html` in the `blog/templates/blog` directory, and open it in the code editor. To make a form work we need several things:
 
 - We have to display the form. We can do that with (for example) {% raw %}`{{ form.as_p }}`{% endraw %}.
-- The line above needs to be wrapped with an HTML form tag: `<form method="POST">...</form>`.
+- The line above needs to be wrapped with an HTML form element: `<form method="POST">...</form>`.
 - We need a `Save` button. We do that with an HTML button: `<button type="submit">Save</button>`.
 - And finally, just after the opening `<form ...>` tag we need to add {% raw %}`{% csrf_token %}`{% endraw %}. This is very important, since it makes your forms secure! If you forget about this bit, Django will complain when you try to save the form:
 
@@ -285,7 +285,7 @@ Now we know how to add a new post. But what if we want to edit an existing one? 
 
 First, let's save the icon which represents the edit button. Download [pencil-fill.svg](https://raw.githubusercontent.com/twbs/icons/main/icons/pencil-fill.svg) and save it to the location `blog/templates/blog/icons/`.
 
-Open `blog/templates/blog/post_detail.html` in the code editor and add the following code inside `article` tag:
+Open `blog/templates/blog/post_detail.html` in the code editor and add the following code inside `article` element:
 
 {% filename %}blog/templates/blog/post_detail.html{% endfilename %}
 ```html
@@ -380,7 +380,7 @@ If you need more information about Django forms, you should read the documentati
 
 Being able to create new posts by clicking a link is awesome! But right now, anyone who visits your site will be able to make a new blog post, and that's probably not something you want. Let's make it so the button shows up for you but not for anyone else.
 
-Open `blog/templates/blog/base.html` in the code editor, find our `div` inside `header` and the anchor tag you put in there earlier. It should look like this:
+Open `blog/templates/blog/base.html` in the code editor, find our `div` inside `header` and the anchor element you put in there earlier. It should look like this:
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html
@@ -389,7 +389,7 @@ Open `blog/templates/blog/base.html` in the code editor, find our `div` inside `
 </a>
 ```
 
-We're going to add another `{% if %}` tag to this, which will make the link show up only for users who are logged into the admin. Right now, that's just you! Change the `<a>` tag to look like this:
+We're going to add another `{% if %}` tag to this, which will make the link show up only for users who are logged into the admin. Right now, that's just you! Change the `<a>` element to look like this:
 
 {% filename %}blog/templates/blog/base.html{% endfilename %}
 ```html


### PR DESCRIPTION
Use term "element" to refer to HTML elements as a whole, and only use "tag" when referring to the tags (usually) delimiting it (or when talking about Django template tags or Git tags, of course.)

Changes in this pull request:

- replace "tag" by "element" where appropriate