### PR TITLE
Blank line before filename macro

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -145,7 +145,7 @@ ALLOWED_HOSTS = ['127.0.0.1', '.pythonanywhere.com']
 >     ```python
 >     SECRET_KEY = os.getenv('SECRET')
 >     ```
->   * And a little further, in the same file, we inject the name of your new Glitch website:
+>   * And a little further down in the same file, we inject the name of your new Glitch website:
 >
 >     {% filename %}mysite/settings.py{% endfilename %}
 >     ```python

--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -124,7 +124,7 @@ ALLOWED_HOSTS = ['127.0.0.1', '.pythonanywhere.com']
 >   * First, we are going to create a random secret key.
 >     Open the Glitch terminal again, and type the following command:
 >
->     {% filename %}.env{% endfilename %}
+>     {% filename %}command-line{% endfilename %}
 >     ```bash
 >     python -c 'from django.core.management.utils import get_random_secret_key; \
 >           print(get_random_secret_key())'

--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -123,6 +123,7 @@ ALLOWED_HOSTS = ['127.0.0.1', '.pythonanywhere.com']
 >
 >   * First, we are going to create a random secret key.
 >     Open the Glitch terminal again, and type the following command:
+>
 >     {% filename %}.env{% endfilename %}
 >     ```bash
 >     python -c 'from django.core.management.utils import get_random_secret_key; \
@@ -132,17 +133,20 @@ ALLOWED_HOSTS = ['127.0.0.1', '.pythonanywhere.com']
 >     We will now paste this key into a `.env` file that Glitch will only show you if you are the owner of the web site.    
 >   
 >   * Create a file `.env` at the root of your project and add the following property in it:
+>
 >     {% filename %}.env{% endfilename %}
 >     ```bash
 >     # Here, inside the single quotes, you can cut and paste the random key generated above
 >     SECRET='3!0k#7ds5mp^-x$lqs2%le6v97h#@xopab&oj5y7d=hxe511jl'
 >     ```
 >   * Then update the Django settings file to inject this secret value and set the Django web site name:
+>
 >     {% filename %}mysite/settings.py{% endfilename %}
 >     ```python
 >     SECRET_KEY = os.getenv('SECRET')
 >     ```
 >   * And a little further, in the same file, we inject the name of your new Glitch website:
+>
 >     {% filename %}mysite/settings.py{% endfilename %}
 >     ```python
 >     ALLOWED_HOSTS = [os.getenv('PROJECT_DOMAIN') + ".glitch.me"]


### PR DESCRIPTION
Changes in this pull request:

- d7d128d add blank lines before` {% filename %}` so that Crowdin won't lose the linebreak and thereby break the markup (See https://crowdin.com/translate/django-girls-tutorial/306/en-de#14746)
- b53c420 change code block label, as `python -c ...` is for the command line, not the `.env` file
- 3a0cbae minor rephrasing, so that the sentence flows more IMO naturally: "a little further, in the same file<strong>,</strong> we inject ..." &rarr; "a little further **down** in the same file, we inject ..."
