### PR TITLE
 Add import os.

### DIFF
--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -169,6 +169,12 @@ DATABASES = {
     }
 }
 ```
+To be able to use `os` module here `'NAME': os.path.join(BASE_DIR, 'db.sqlite3')` we have to add it in import section, at the beggining of `settings.py` file.
+
+{% filename %}mysite/settings.py{% endfilename %}
+```python
+import os
+```
 
 To create a database for our blog, let's run the following in the console: `python manage.py migrate` (we need to be in the `djangogirls` directory that contains the `manage.py` file). If that goes well, you should see something like this:
 

--- a/en/django_start_project/README.md
+++ b/en/django_start_project/README.md
@@ -169,7 +169,7 @@ DATABASES = {
     }
 }
 ```
-To be able to use `os` module here `'NAME': os.path.join(BASE_DIR, 'db.sqlite3')` we have to add it in import section, at the beggining of `settings.py` file.
+To be able to use the `os` module here `'NAME': os.path.join(BASE_DIR, 'db.sqlite3')` we have to add it in the import section, at the beginning of the `settings.py` file.
 
 {% filename %}mysite/settings.py{% endfilename %}
 ```python


### PR DESCRIPTION
 Without importing os module, database creation with **python manage.py migrate** command will crush with error:
```
   'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
   NameError: name 'os' is not defined
```

