### PR TITLE
Fix: Consistently use settings.AUTH_USER_MODE in all languages

### DIFF
--- a/cs/django_models/README.md
+++ b/cs/django_models/README.md
@@ -110,12 +110,13 @@ V souboru `blog/models.py` budeme definovat všechny objekty nazývané `modely`
 Otevři `blog/models.py`, odstraň vše, co v něm je, a vlož následující kód:
 
 ```python
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/es/django_models/README.md
+++ b/es/django_models/README.md
@@ -121,12 +121,13 @@ Abre `blog/models.py` en el editor, borra todo, y escribe código como este:
 {% filename %}blog/models.py{% endfilename %}
 
 ```python
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/fa/django_models/README.md
+++ b/fa/django_models/README.md
@@ -123,12 +123,13 @@ INSTALLED_APPS = [
 {% filename %}blog/models.py{% endfilename %}
 
 ```python
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/hu/django_models/README.md
+++ b/hu/django_models/README.md
@@ -101,12 +101,13 @@ A `Model` nevű objektumokat a `blog/models.py` fájlban definiáljuk - tehát i
 Nyisd meg a `blog/models.py`-t, törölj ki mindent, és ezt a kódot írd bele:
 
 ```python
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/pl/django_models/README.md
+++ b/pl/django_models/README.md
@@ -121,12 +121,13 @@ Otwórz plik `blog/models.py` w swoim edytorze kodu, usuń z niego całą zawart
 {% filename %}blog/models.py{% endfilename %}
 
 ```python
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/sk/django_models/README.md
+++ b/sk/django_models/README.md
@@ -124,12 +124,13 @@ Otvor `blog/models.py`, všetko z neho odstráň a napíš nasledovný kód:
 {% filename %}blog/models.py{% endfilename %}
 
 ```python
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/tr/django_models/README.md
+++ b/tr/django_models/README.md
@@ -120,12 +120,13 @@ INSTALLED_APPS = [
 {% filename %}blog/models.py{% endfilename %}
 
 ```python
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/uk/django_models/README.md
+++ b/uk/django_models/README.md
@@ -102,12 +102,13 @@ INSTALLED_APPS = (
 Відкриємо `blog/models.py`, видалимо все звідси та запишемо наступний код:
 
 ```python
+from django.conf import settings
 from django.db import models
 from django.utils import timezone
 
 
 class Post(models.Model):
-    author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+    author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     title = models.CharField(max_length=200)
     text = models.TextField()
     created_date = models.DateTimeField(

--- a/zh/django_models/README.md
+++ b/zh/django_models/README.md
@@ -104,12 +104,13 @@ Django 里的模型是一种特殊的对象 — — 它保存在 `数据库` 中
 
 让我们打开 `blog/models.py`，从中删除一切并编写这样的代码：
 
+    from django.conf import settings
     from django.db import models
     from django.utils import timezone
     
     
     class Post(models.Model):
-        author = models.ForeignKey('auth.User', on_delete=models.CASCADE)
+        author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
         title = models.CharField(max_length=200)
         text = models.TextField()
         created_date = models.DateTimeField(


### PR DESCRIPTION
`settings.AUTH_USER_MODE` was already being used in many languages, but not all of them. This PR changes the pending languages still using the old way to reference the User model.