### PR TITLE
Fix: Refer to article tags instead of div

### DIFF
--- a/en/django_templates/README.md
+++ b/en/django_templates/README.md
@@ -19,7 +19,7 @@ To print a variable in Django templates, we use double curly brackets with the v
 {{ posts }}
 ```
 
-Try this in your `blog/templates/blog/post_list.html` template. Open it up in the code editor, and replace everything from the second `<div>` to the third `</div>` with `{{ posts }}`. Save the file, and refresh the page to see the results:
+Try this in your `blog/templates/blog/post_list.html` template. Open it up in the code editor, and replace the existing `<article>` blocks with `{{ posts }}`. Save the file, and refresh the page to see the results:
 
 ![Figure 13.1](images/step1.png)
 

--- a/en/django_templates/README.md
+++ b/en/django_templates/README.md
@@ -19,7 +19,7 @@ To print a variable in Django templates, we use double curly brackets with the v
 {{ posts }}
 ```
 
-Try this in your `blog/templates/blog/post_list.html` template. Open it up in the code editor, and replace the existing `<article>` blocks with `{{ posts }}`. Save the file, and refresh the page to see the results:
+Try this in your `blog/templates/blog/post_list.html` template. Open it up in the code editor, and replace the existing `<article>` elements with `{{ posts }}`. Save the file, and refresh the page to see the results:
 
 ![Figure 13.1](images/step1.png)
 


### PR DESCRIPTION
In commit https://github.com/DjangoGirls/tutorial/commit/a9dbbf582e5e863bbb4ef50a16201a2b758a81f9, the `<div>` tags for the blog posts where changed to `<article>`, but this reference wasn't updated.