### PR TITLE
[es] Using `Path.__truediv__` instead of `os` module.

### DIFF
--- a/es/django_start_project/README.md
+++ b/es/django_start_project/README.md
@@ -96,7 +96,7 @@ También tenemos que añadir una ruta para archivos estáticos. (Veremos todo ac
 
 ```python
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = BASE_DIR / 'static' 
 ```
 
 Cuando `DEBUG` es `True` y `ALLOWED_HOST` esta vacío, el host es validado contra `['localhost', '127,0.0.1', '[::1]']`. Una vez despleguemos nuestra aplicación este no sera el mismo que nuestro nombre de host en PythonAnywhere así que cambiaremos la siguiente opción:


### PR DESCRIPTION
Changes in this pull request:

- This uses the `/` operator for `Path` objects to concatenate paths, instead of relying on the `os` module.

Resolves #1763 