### PR TITLE
Add a job to automatically update translations

### DIFF
--- a/.github/list_languages
+++ b/.github/list_languages
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import json
+import os
+from pathlib import Path
+
+
+def main():
+    directory = Path(__file__).absolute().parent.parent
+    languages = sorted(x.name for x in directory.iterdir()
+                       if x.is_dir() and len(x.name) == 2 and x.name != 'en')
+
+    if 'GITHUB_ACTION' in os.environ:
+        print(f'::set-output name=languages::{json.dumps(languages)}')
+    for language in languages:
+        print(language)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -1,0 +1,52 @@
+name: Update translations
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '4 4 * * 0'
+
+env:
+  GIT_AUTHOR_NAME: Django Girls Automation
+  GIT_AUTHOR_EMAIL: automation@theforeman.org
+
+jobs:
+  list_languages:
+    name: List languages
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'djangogirls'
+    outputs:
+      languages: ${{ steps.set_list.outputs.languages }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set the language list
+        id: set_list
+        run: ./.github/list_languages
+
+  update_language:
+    name: 'Update ${{ matrix.language }} translations from Crowdin'
+    needs: list_languages
+    if: ${{ needs.list_languages.outputs.languages != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJson(needs.list_languages.outputs.languages) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Update language
+        run: |
+          wget https://crowdin.com/backend/download/project/django-girls-tutorial/${{ matrix.language }}.zip
+          unzip ${{ matrix.language }}.zip
+          find ${{ matrix.language }} -name '*.md' -delete
+          rsync -av master/${{ matrix.language }}*/* ${{ matrix.language }}/
+          rm -rf ${{ matrix.language }}.zip master
+      - name: Open a PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "Update ${{ matrix.language }} translations from Crowdin"
+          branch: "update_translations/${{ matrix.language }}"
+          title: "Update ${{ matrix.language }} translations from Crowdin"
+          body: ''
+          delete-branch: true


### PR DESCRIPTION
This job runs weekly (or explicitly manual). It lists the languages in a way tht GitHub Actions can reuse it in a matrix. Then for every language it updates the translations and creates a PR in a branch for every language.