### PR TITLE
Ignore the default branch name problem

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -31,23 +31,6 @@ $ git config --global user.email you@example.com
 ```
 Initializing the git repository is something we need to do only once per project (and you won't have to re-enter the username and email ever again).
 
-### Adjusting your branch name
-
-If the version of Git that you are using is older than **2.28**, you will need to change the name of your branch to "main". To determine the version of Git, please enter the following command:
-
-{% filename %}command-line{% endfilename %}
-```
-$ git --version
-git version 2.xx...
-```
-
-Only if the second number of the version, shown as "xx" above, is less than 28, will you need to enter the following command to rename your branch. If it is 28 or higher, please continue to "Ignoring files". As in "Initializing", this is something we need to do only once per project, as well as only when your version of Git is less than 2.28:
-
-{% filename %}command-line{% endfilename %}
-```
-$ git branch -M main
-```
-
 ### Ignoring files
 
 Git will track changes to all the files and folders in this directory, but there are some files we want it to ignore. We do this by creating a file called `.gitignore` in the base directory. Open up your editor and create a new file with the following contents:
@@ -153,7 +136,7 @@ Type the following into your console (replace `<your-github-username>` with the 
 {% filename %}command-line{% endfilename %}
 ```
 $ git remote add origin https://github.com/<your-github-username>/my-first-blog.git
-$ git push -u origin main
+$ git push -u origin HEAD
 ```
 
 When you push to GitHub, you'll be asked for your GitHub username and password (either right there in the command-line window or in a pop-up window), and after entering credentials you should see something like this:

--- a/en/deploy/install_git.md
+++ b/en/deploy/install_git.md
@@ -7,8 +7,6 @@ data-collapse=true ces-->
 
 You can download Git from [git-scm.com](https://git-scm.com/). You can hit "next" on all steps except for two: in the step where it asks to choose your editor, you should pick Nano, and in the step entitled "Adjusting your PATH environment", choose "Use Git and optional Unix tools from the Windows Command Prompt" (the bottom option). Other than that, the defaults are fine. Checkout Windows-style, commit Unix-style line endings is good.
 
-During installation, if you are presented with the option of "Adjusting the name of the initial branch in new repositories", please choose to "Override the default" and use "main". This will align your installation of Git with the broad direction of the global developer community, and the "main" branch will be used through the remainder of this tutorial. Please see https://sfconservancy.org/news/2020/jun/23/gitbranchname/ and https://github.com/github/renaming for further discussion of this subject. 
-
 Do not forget to restart the command prompt or PowerShell after the installation finished successfully.
 <!--endsec-->
 
@@ -16,8 +14,6 @@ Do not forget to restart the command prompt or PowerShell after the installation
 data-collapse=true ces-->
 
 Download Git from [git-scm.com](https://git-scm.com/) and follow the instructions.
-
-During installation, if you are presented with the option of "Adjusting the name of the initial branch in new repositories", please choose to "Override the default" and use "main". This will align your installation of Git with the broad direction of the global developer community, and the "main" branch will be used through the remainder of this tutorial. Please see https://sfconservancy.org/news/2020/jun/23/gitbranchname/ and https://github.com/github/renaming for further discussion of this subject. 
 
 > **Note** If you are running OS X 10.6, 10.7, or 10.8, you will need to install the version of git from here: [Git installer for OS X Snow Leopard](https://sourceforge.net/projects/git-osx-installer/files/git-2.3.5-intel-universal-snow-leopard.dmg/download)
 
@@ -31,15 +27,6 @@ data-collapse=true ces-->
 $ sudo apt install git
 ```
 
-### Adjusting your default branch name
-
-This will align your installation of Git with the broad direction of the global developer community, and the "main" branch will be used through the remainder of this tutorial. Please see https://sfconservancy.org/news/2020/jun/23/gitbranchname/ and https://github.com/github/renaming for further discussion of this subject. 
-
-{% filename %}command-line{% endfilename %}
-```
-$ git config --global --add init.defaultBranch main
-```
-
 <!--endsec-->
 
 <!--sec data-title="Installing Git: Fedora" data-id="git_install_fedora"
@@ -50,15 +37,6 @@ data-collapse=true ces-->
 $ sudo dnf install git
 ```
 
-### Adjusting your default branch name
-
-This will align your installation of Git with the broad direction of the global developer community, and the "main" branch will be used through the remainder of this tutorial. Please see https://sfconservancy.org/news/2020/jun/23/gitbranchname/ and https://github.com/github/renaming for further discussion of this subject. 
-
-{% filename %}command-line{% endfilename %}
-```
-$ git config --global --add init.defaultBranch main
-```
-
 <!--endsec-->
 
 <!--sec data-title="Installing Git: openSUSE" data-id="git_install_openSUSE"
@@ -67,15 +45,6 @@ data-collapse=true ces-->
 {% filename %}command-line{% endfilename %}
 ```bash
 $ sudo zypper install git
-```
-
-### Adjusting your default branch name
-
-This will align your installation of Git with the broad direction of the global developer community, and the "main" branch will be used through the remainder of this tutorial. Please see https://sfconservancy.org/news/2020/jun/23/gitbranchname/ and https://github.com/github/renaming for further discussion of this subject. 
-
-{% filename %}command-line{% endfilename %}
-```
-$ git config --global --add init.defaultBranch main
 ```
 
 <!--endsec-->


### PR DESCRIPTION
With older versions of git the command to rename the branch fails if there is no branch yet. We're also making the tutorial harder than it needs to be.

This ignores it and simply uses the default by pushing HEAD instead of main. GitHub is then smart enough to use that as default. Future clones will also simply copy the default branch from GitHub.

Fixes #1779