### PR TITLE
Fix broken links in Japanese text

### DIFF
--- a/ja/django_templates/README.md
+++ b/ja/django_templates/README.md
@@ -101,7 +101,7 @@ post変数がさっきと違って、`{{ post.title }}` や `{{ post.text }}` �
 
 * 最後にPythonAnywhereの[「Web」ページ](https://www.pythonanywhere.com/web_app_setup/)を開いて、アプリを**リロード**（Reload）します。 （コンソールからPythonAnywhereの他のページにアクセスするには、右上のメニューボタンを使います。）更新された内容が、 https://subdomain.pythonanywhere.com に反映されているはずです。ブラウザで確認してみましょう！ PythonAnywhereサイトで表示されるブログの記事が、あなたのパソコンの中のローカルサーバーのものと違っていても大丈夫です。 ローカルコンピュータにあるデータベースと、PythonAnywhere上のデータベースは同期していません。
 
-頑張りましたね！ さぁ、ここまでできたら、Django 管理画面から新しい投稿を追加してみましょう。（published_date 公開日の設定を忘れずに！）投稿を追加する時、PythonAnywhereのサイトの管理画面（https://subdomain.pythonanywhere.com/admin）であることを確認してください 。できたら、リロードして投稿したものが表示されるか見てみましょう。
+頑張りましたね！ さぁ、ここまでできたら、Django 管理画面から新しい投稿を追加してみましょう。（published_date 公開日の設定を忘れずに！）投稿を追加する時、PythonAnywhereのサイトの管理画面（<https://subdomain.pythonanywhere.com/admin>）であることを確認してください 。できたら、リロードして投稿したものが表示されるか見てみましょう。
 
 うまく動きましたか？ここまでよく頑張りましたね！少しパソコンから離れて、休憩をとりましょう。^_^
 


### PR DESCRIPTION
Changes in this pull request:

- Fix broken links in Japanese text

before
![before](https://user-images.githubusercontent.com/301892/224308131-e859e8a6-3427-40ff-9bf2-68c679d22188.jpg)

after
![after](https://user-images.githubusercontent.com/301892/224308183-d5b05603-f671-44f0-b4ae-5f56971c1bf6.jpg)
