### PR TITLE
Replace sidebar-ad with sidebar-ads plugin

### DIFF
--- a/book.json
+++ b/book.json
@@ -22,7 +22,7 @@
         "richquotes@0.0.9",
         "github@2.0.0",
         "language-picker",
-        "sidebar-ad",
+        "sidebar-ads",
         "codeblock-label",
         "sectionx-ex",
         "collapsible-menu"
@@ -40,11 +40,51 @@
         "language-picker": {
             "grid-columns": 3
         },
-        "sidebar-ad": {
-            "imageUrl": "https://djangogirls.org/static/img/global/donate/lagos.jpg",
-            "url": "https://www.patreon.com/djangogirls",
-            "description": "💖 Support our work and donate to our project! ✨",
-            "btnText": "Donate now!"
+        "sidebar-ads": {
+            "ads": [
+                {
+                    "imageUrl": "https://djangogirls.org/static/img/global/donate/lagos.jpg",
+                    "url": "https://www.patreon.com/djangogirls",
+                    "description": "💖 Support our work and donate to our project! ✨",
+                    "btnText": "Donate now!"
+                },
+                {
+                    "imageUrl": "https://posthog.com/static/1cf376d3f6ea36d7fafb9b1c50110603/0b2f4/hosthog-banner.webp",
+                    "url": "https://posthog.com/",
+                    "description": "💖 PostHog offers a suite of product analysis tools! ✨",
+                    "btnText": "Learn more!"
+                },
+                {
+                    "imageUrl": "https://static.djangoproject.com/img/logos/django-logo-negative.png",
+                    "url": "https://www.djangoproject.com/",
+                    "description": "💖 The DSF supports the development of Django! ✨",
+                    "btnText": "Learn more!"
+                },
+                {
+                    "imageUrl": "https://djangogirls.org/uploads/uploads/lincolnloop.png",
+                    "url": "https://lincolnloop.com/",
+                    "description": "💖 Lincoln Loop provides scalable content platforms! ✨",
+                    "btnText": "Learn more!"
+                },
+                {
+                    "imageUrl": "https://djangogirls.org/uploads/uploads/torchbox.png",
+                    "url": "https://torchbox.com/",
+                    "description": "💖 Torchbox, the creators of Wagtail! ✨",
+                    "btnText": "Learn more!"
+                },
+                {
+                    "imageUrl": "https://www.pythonanywhere.com/static/anywhere/images/PA-logo.svg",
+                    "url": "https://www.pythonanywhere.com/",
+                    "description": "💖 Host, run, and code Python in the cloud! ✨",
+                    "btnText": "Learn more! "
+                },
+                {
+                    "imageUrl": "https://djangogirls.org/static/img/global/donate/tshirt.jpg",
+                    "url": "https://djangogirls.org/en/contact/",
+                    "description": "💖 Want to support our work? ✨",
+                    "btnText": "Contact Us!"
+                }
+            ]
         },
         "sectionx": {
             "tag": "b"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gitbook-plugin-language-picker": "*",
     "gitbook-plugin-richquotes": "0.0.9",
     "gitbook-plugin-sectionx-ex": "*",
-    "gitbook-plugin-sidebar-ad": "*",
+    "gitbook-plugin-sidebar-ads": "^1.0.0",
     "honkit": "^3.4.0"
   },
   "scripts": {},


### PR DESCRIPTION
Changes in this pull request:

- Replace gitbook-plugin-sidebar-ad with gitbook-plugin-sidebar-ads
- Add sponsor ads to book.json and extra ad for Django Girls

The new ad looks like the video below:

https://user-images.githubusercontent.com/13593285/227919231-c0b9d8d5-1e3c-4498-a501-26ba683ec146.mov




