### PR TITLE
Switch to actions/deploy-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,27 +1,47 @@
+---
 name: Build and Deploy
+
 on:
   push:
     branches:
       - master
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
-    if: github.repository == 'djangogirls/tutorial'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
-
       - name: Install and Build
         run: |
           npm install
           npx honkit build
-
-      - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: _book
+          path: _book
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This uses the currently beta feature of using GitHub Actions to deploy GitHub Pages, rather than using a gh-pages branch. This keeps the repository size smaller.

While this feature is beta, it is used [by default](https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/).

This does require a change on the repo itself and since I don't have the permissions, someone else will need to do this. https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/ shows how to.

This will make it easier to publish large artifacts, such as ebooks (see https://github.com/DjangoGirls/tutorial/issues/1785).