### PR TITLE
Move branch rename instructions after ignoring files. Fix #1779

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -31,23 +31,6 @@ $ git config --global user.email you@example.com
 ```
 Initializing the git repository is something we need to do only once per project (and you won't have to re-enter the username and email ever again).
 
-### Adjusting your branch name
-
-If the version of Git that you are using is older than **2.28**, you will need to change the name of your branch to "main". To determine the version of Git, please enter the following command:
-
-{% filename %}command-line{% endfilename %}
-```
-$ git --version
-git version 2.xx...
-```
-
-Only if the second number of the version, shown as "xx" above, is less than 28, will you need to enter the following command to rename your branch. If it is 28 or higher, please continue to "Ignoring files". As in "Initializing", this is something we need to do only once per project, as well as only when your version of Git is less than 2.28:
-
-{% filename %}command-line{% endfilename %}
-```
-$ git branch -M main
-```
-
 ### Ignoring files
 
 Git will track changes to all the files and folders in this directory, but there are some files we want it to ignore. We do this by creating a file called `.gitignore` in the base directory. Open up your editor and create a new file with the following contents:
@@ -131,6 +114,22 @@ $ git commit -m "My Django Girls app, first commit"
  create mode 100644 mysite/wsgi.py
 ```
 
+### Adjusting your branch name
+
+If the version of Git that you are using is older than **2.28**, you will need to change the name of your branch to "main". To determine the version of Git, please enter the following command:
+
+{% filename %}command-line{% endfilename %}
+```
+$ git --version
+git version 2.xx...
+```
+
+Only if the second number of the version, shown as "xx" above, is less than 28, will you need to enter the following command to rename your branch. If it is 28 or higher, please continue to "Pushing your code to GitHub". As in "Initializing", this is something we need to do only once per project, as well as only when your version of Git is less than 2.28:
+
+{% filename %}command-line{% endfilename %}
+```
+$ git branch -M main
+```
 
 ## Pushing your code to GitHub
 


### PR DESCRIPTION
Fixes #1779. This is an alternative to #1780, focusing on fixing the specific issue of `git branch -M` failing before there’s a commit. This should be really helpful for users of RunCode in particular (Ubuntu 20), who would otherwise get a cryptic error message at this step. Compared to #1780, this does nothing to simplify the tutorial. 

---

I chose to move the "Adjusting your branch name" instructions as close to as-is as possible. With this approach, the `git status` output in the previous step would still say "On branch master" for git users below v2.28, which can be confusing. I assumed that was a reasonable trade-off. If we want to address this too, I think we could add a note after the `git status output`:

```diff
+ Note the default branch name will be `master` on git versions older than **2.28**. We will address this in the next section.
```