### PR TITLE
Simplify Google Fonts link element

### DIFF
--- a/en/css/README.md
+++ b/en/css/README.md
@@ -159,7 +159,7 @@ Maybe we can customize the font in our header? Paste this into your `<head>` in 
 
 {% filename %}blog/templates/blog/post_list.html{% endfilename %}
 ```html
-<link href="//fonts.googleapis.com/css?family=Lobster&subset=latin,latin-ext" rel="stylesheet" type="text/css">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lobster&subset=latin,latin-ext">
 ```
 
 As before, check the order and place before the link to `blog/static/css/blog.css`. This line will import a font called *Lobster* from Google Fonts (https://www.google.com/fonts).

--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -71,7 +71,7 @@ After editing the line, your HTML file should now look like this:
     <head>
         <title>Django Girls blog</title>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-        <link href='//fonts.googleapis.com/css?family=Lobster&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lobster&subset=latin,latin-ext">
         <link rel="stylesheet" href="{% static 'css/blog.css' %}">
     </head>
     <body>

--- a/en/template_extending/README.md
+++ b/en/template_extending/README.md
@@ -28,7 +28,7 @@ Then open it up in the code editor and copy everything from `post_list.html` to 
     <head>
         <title>Django Girls blog</title>
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-        <link href='//fonts.googleapis.com/css?family=Lobster&subset=latin,latin-ext' rel='stylesheet' type='text/css'>
+        <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lobster&subset=latin,latin-ext">
         <link rel="stylesheet" href="{% static 'css/blog.css' %}">
     </head>
     <body>


### PR DESCRIPTION
Simplifies the `link` element used for Google Fonts, so it’s easier for beginners to follow:

- Its attributes should use the same quote style as other elements.
- `rel="stylesheet"` should come first, to match other `link` elements.
- No need for a protocol-relative URL, we can load the HTTPS version everywhere.
- `type="text/css"` does nothing, it can be removed.