### PR TITLE
Provide more information for RunCode users choosing a workspace

### DIFF
--- a/en/cloud_development_setup/instructions.md
+++ b/en/cloud_development_setup/instructions.md
@@ -13,7 +13,7 @@ which you can sign up with.
 {% include "/deploy/signup_pythonanywhere.md" %}
 
 ## Command Line
-To open the Ubuntu terminal on RunCode, go to Workspaces → New Workspace → Blank. This will open a new Visual Studio Code workspace which has an Ubuntu terminal in the bottom pane.
+To open the Ubuntu terminal on RunCode, go to Workspaces → New Workspace → Blank, and select the “Tiny” Workspace Type. After waiting for it to start, this will open a new Visual Studio Code workspace which has an Ubuntu terminal in the bottom pane.
 
 Altenatively, you can go to Workspaces → New Workspace → Jupyter Lab. This will open a Python prompt which is depicted by `>>>`, you can type `exit()` to get back to the Ubuntu terminal.
 

--- a/en/intro_to_command_line/open_instructions.md
+++ b/en/intro_to_command_line/open_instructions.md
@@ -29,7 +29,7 @@ It's probably under Applications → Accessories → Terminal, or Applications �
 <!--sec data-title="Opening: RunCode" data-id="runcode_prompt" data-collapse=true ces-->
 > **NOTE** If you followed [RunCode setup instructions](../cloud_development_setup/README.md) follow these steps to open command line.
 
-To open the Ubuntu terminal on RunCode, go to Workspaces → New Workspace → Blank. This will open a new Visual Studio Code workspace which has an Ubuntu terminal in the bottom pane.
+If you already created a Workspace on RunCode, access it again from the Dashobard. To open a new workspace with the the Ubuntu terminal on RunCode, go to Workspaces → New Workspace → Blank, and select the “Tiny” Workspace Type. This will open a new Visual Studio Code workspace which has an Ubuntu terminal in the bottom pane.
 
 Altenatively, you can go to Workspaces → New Workspace → Jupyter Lab. This will open a Python prompt which is depicted by `>>>`, you can type `exit()` to get back to the Ubuntu terminal.
 


### PR DESCRIPTION
After selecting the "Blank" workspace type, there is another step to select a size. I think it helps if the tutorial explicitly says which size should be used. And acknowledges it takes a while for it to start.

Additionally, in "intro to command line", it’d be clearer for users if they reused the workspace they’ve created before, rather than having multiple ones to manage.