### PR TITLE
remove suggestions to use Jupyter Lab workspace

### DIFF
--- a/en/cloud_development_setup/instructions.md
+++ b/en/cloud_development_setup/instructions.md
@@ -15,8 +15,6 @@ which you can sign up with.
 ## Command Line
 To open the Ubuntu terminal on RunCode, go to Workspaces → New Workspace → Blank. This will open a new Visual Studio Code workspace which has an Ubuntu terminal in the bottom pane.
 
-Altenatively, you can go to Workspaces → New Workspace → Jupyter Lab. This will open a Python prompt which is depicted by `>>>`, you can type `exit()` to get back to the Ubuntu terminal.
-
 Ubuntu is a version of Linux so for all command line instructions later in the tutorial you can follow Linux instructions.
 
 ## Virtual Environment

--- a/en/intro_to_command_line/open_instructions.md
+++ b/en/intro_to_command_line/open_instructions.md
@@ -31,8 +31,6 @@ It's probably under Applications → Accessories → Terminal, or Applications �
 
 To open the Ubuntu terminal on RunCode, go to Workspaces → New Workspace → Blank. This will open a new Visual Studio Code workspace which has an Ubuntu terminal in the bottom pane.
 
-Altenatively, you can go to Workspaces → New Workspace → Jupyter Lab. This will open a Python prompt which is depicted by `>>>`, you can type `exit()` to get back to the Ubuntu terminal.
-
 Ubuntu is a version of Linux so from now on you can follow Linux instructions.
 
 <!--endsec-->

--- a/en/python_introduction/prompt.md
+++ b/en/python_introduction/prompt.md
@@ -15,12 +15,3 @@ Python {{ book.py_release }} (...)
 Type "help", "copyright", "credits" or "license" for more information.
 >>>
 ```
-
-<!--sec data-title="Opening: RunCode Cloud Environment" data-id="runcode_prompt" data-collapse=true ces-->
-
-To open the Python terminal on RunCode, go to Workspaces → New Workspace → Jupyter Lab. This will open a Python prompt 
-which is depicted by `>>>`. If you already opened an Ubuntu terminal open, in the [Intro to Command Line](../intro_to_command_line/README.md) chapter, you can just type `python3` in the prompt as shown below to open a Python prompt.
-
-`ubuntu@runcode:~$ python3`
-
-<!--endsec-->


### PR DESCRIPTION
fixes #1805

Changes in this pull request:

- Remove suggestions to use Jupyter Lab workspace in RunCode, as (for this tutorial) there's probably no advantage to use a Jupyter Lab workspace over using RunCode's default VSCode based workspaces, but indeed some disadvantages, as #1805 mentions. (Fewer unneeded options to choose from also simplifies the work of coaches and of those maintaining the tutorial.)
- Remove all mentions of how to open a command line window or Python prompt in a Jupyter Lab workspace

- Completely remove the special case for RunCode users in the "Python prompt" section, as at that point, they've already been told to follow Linux instructions.