### PR TITLE
Update Python and Django versions.

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,12 +1,12 @@
 {
     "gitbook": ">=3.2.0",
     "variables": {
-      "py_version": "3.8",
-      "py_release": "3.8.6",
-      "py_min_version": "3.6",
-      "py_min_release": "3.6.8",
-      "pa_py_version": "3.8",
-      "django_version": "3.2.10"
+      "py_version": "3.10",
+      "py_release": "3.10.13",
+      "py_min_version": "3.8",
+      "py_min_release": "3.8.18",
+      "pa_py_version": "3.10",
+      "django_version": "4.2.9"
     },
     "links": {
         "sidebar": {


### PR DESCRIPTION
Changes in this pull request:

Python 3.6 is no longer supported, and 3.8 has a few more months. I took two people through the tutorial yesterday, and Python 3.10 is the most recent version supported by Python Anywhere for deployment. So I've set the Python version to 3.10, Django version to 4.2, and minimum version to 3.8.
