### PR TITLE
Remove gitter.im links from the homepage and the sidebar

### DIFF
--- a/book.json
+++ b/book.json
@@ -9,9 +9,6 @@
       "django_version": "4.2.11"
     },
     "links": {
-        "sidebar": {
-            "Need help? Talk to us!": "https://gitter.im/DjangoGirls/tutorial"
-        }
     },
     "pdf": {
         "fontSize": 16

--- a/en/README.md
+++ b/en/README.md
@@ -1,5 +1,4 @@
 # Django Girls Tutorial
-[![Gitter](https://badges.gitter.im/DjangoGirls/tutorial.svg)](https://gitter.im/DjangoGirls/tutorial)
 
 > This work is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License.
 > To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
@@ -26,8 +25,6 @@ Once you've finished the tutorial, you will have a small working web application
 It will (more or less) look like this:
 
 ![Figure 0.1](images/application.png)
-
-> If you work with the tutorial on your own and don't have a coach who will help you in case of any problem, we have a chat system for you: [![Gitter](https://badges.gitter.im/DjangoGirls/tutorial.svg)](https://gitter.im/DjangoGirls/tutorial). We asked our coaches and previous attendees to be there from time to time and help others with the tutorial! Don't be afraid to ask your question there!
 
 OK, [let's start at the beginning…](./how_the_internet_works/README.md)
 


### PR DESCRIPTION
The `gitter.im` chat seems to be abandoned between DjangoGirls events, and is filled with **very bad** spam (I'm not repeating here the things that are inside the chat), so maybe it's better to remove the links for now, if the chat isn't moderated, to avoid looking bad if someone clicks on the link(s) and enters there.

Changes in this pull request:

- Removed the `gitter.im` links from the `README.md` file
- Removed the `gitter.im` link from the sidebar

I did the work only in the English language file.