### PR TITLE
Use Ubuntu 24.04 for rename from util-linux

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
       - uses: awalsh128/cache-apt-pkgs-action@v1
         with:
-          packages: calibre rename
+          packages: calibre
       - name: Install and Build
         run: |
           npm install
@@ -46,7 +46,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
<del>I'm unsure why this broke.</del> I also looked at https://honkit.netlify.app/ebook which mentions you can publish an ebook with a specific name, but figured this was the shortest path. It's untested now.

Right after submitting this I had a theory why it broke. On the first run it passed, but after that it started to fail. The first run it couldn't have cached the package with `awalsh128/cache-apt-pkgs-action` while it has on the later runs.

`/usr/bin/rename` is provided via alternatives:

```
Setting up rename (2.02-1) ...
update-alternatives: using /usr/bin/file-rename to provide /usr/bin/rename (rename) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/rename.1.gz because associated file /us
r/share/man/man1/file-rename.1p.gz (of link group rename) doesn't exist
```

I suspect `awalsh128/cache-apt-pkgs-action` ignores alternatives so `/usr/bin/rename` isn't present when a cache is used.

This updates to Ubuntu 24.04 and relies on `rename` from `util-linux` which bypasses the need to cache it altogether.

I can't think of an easy way to test this.

Fixes #1855