### PR TITLE
Install rename in Github deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
           packages: calibre
       - name: Install and Build
         run: |
+          sudo apt install rename
           npm install
           npx honkit build
           npx honkit epub


### PR DESCRIPTION
Changes in this pull request:

- Add command to install `rename` to fix `rename: command not found` error.

