### PR TITLE
[Portuguese] Add "--python=3.10" flag to "pa_autoconfigure_django" command in the "Deploy!" step

### DIFF
--- a/pt/deploy/README.md
+++ b/pt/deploy/README.md
@@ -155,7 +155,7 @@ Agora vamos executar a ferramenta para configurar a nossa aplicação a partir d
 
 {% filename %}linha de comando do PythonAnywhere{% endfilename %}
 
-    $ pa_autoconfigure_django.py https://github.com/<your-github-username>/my-first-blog.git
+    $ pa_autoconfigure_django.py --python=3.10 https://github.com/<your-github-username>/my-first-blog.git
     
 
 Enquanto assiste a execução da ferramenta, você pode ver o que ela está fazendo:


### PR DESCRIPTION
Changes in this pull request:

- Add `--python=3.10` to `pa_autoconfigure_django` command in the "Deploy!" step of the portuguese tutorial. Without this flag, the incorrect version of Python is used, causing an error related to the Django version.

Solves one of the problems from #1858 
