### PR TITLE
Django views — improve the intro paragraph

### DIFF
--- a/en/django_views/README.md
+++ b/en/django_views/README.md
@@ -2,7 +2,13 @@
 
 Time to get rid of the bug we created in the last chapter! :)
 
-A *view* is a place where we put the "logic" of our application. It will request information from the `model` you created before and pass it to a `template`. We'll create a template in the next chapter. Views are just Python functions that are a little bit more complicated than the ones we wrote in the __Introduction to Python__ chapter.
+A *view* is a place where we put the "logic" of our application. The views do the following:
+
+1. Receive the `request` information (current user session and other stuff) as well as parameters parsed from the url (for example, the id of a blog post)
+2. Fetch the information from the `model`, probably adding some logic (like filtering logic to show only the published posts)
+3. Create a response by filling a `template` with the fetched info
+
+We'll create a template in the next chapter. Now we'll create a view. Technically, views are Python functions, exactly like the ones we wrote in the __Introduction to Python__ chapter. These functions take `request` as a parameter and return `HttpResponse`. You shouldn't worry about the type of the return value because another function from the Django framework will construct it for us.
 
 Views are placed in the `views.py` file. We will add our *views* to the `blog/views.py` file.
 


### PR DESCRIPTION
I made the intro to the chapter more precise, more clear and more technical.

I split what the view does in 3 clear steps. Each step contains one highlighted technical word (`request`, `model`, `template`) which makes it easier to understand which technical thing is responsible for what. The first step acknowledges that the views receive `request` data as a parameter. The previous version wasn't explicit about it but I think it is important because the `request` is a parameter of a function we are about to write. I added an example of what does "logic" mean in the context of "views are where we put the logic of our application" to the second step. The third step is about filling a `template`. I think "filling a template" is better wording than "passing it to a template".

I rewrote the words "just Python functions that are a little bit more complicated than the ones we wrote" to "Technically, views are Python functions, exactly like the ones we wrote in the Introduction to Python chapter. These functions take `request` as a parameter and return `HttpResponse`". The new wording avoids the word "just" and instead of being vague tells what the difference is between the old functions and the new ones. The resulting paragraph sounds quite technical but I think it comes together nicely with the explanation of the code. The participants will see the `request` in the parameters and their recognition will click because they read about it earlier.
