### PR TITLE
Django forms: POST vs GET explanation

### DIFF
--- a/en/django_forms/README.md
+++ b/en/django_forms/README.md
@@ -189,7 +189,7 @@ def post_new(request):
     return render(request, 'blog/post_edit.html', {'form': form})
 ```
 
-When we submit the form, we are brought back to the same view, but this time we have some more data in `request`, more specifically in `request.POST` (the naming has nothing to do with a blog "post"; it's to do with the fact that we're "posting" data). Remember how in the HTML file, our `<form>` definition had the variable `method="POST"`? All the fields from the form are now in `request.POST`. You should not rename `POST` to anything else (the only other valid value for `method` is `GET`, but we have no time to explain what the difference is).
+When we submit the form, we are brought back to the same view, but this time the `request` parameter is different. If we look at the `request.method` it will be `"POST"` (method for sending forms) instead of `"GET"` (method for requesting pages) and the `request.POST` field will contain all the fields form the form. The naming has nothing to do with a blog "post"; it's to do with the fact that we're "posting" data.
 
 So in our *view* we have two separate situations to handle: first, when we access the page for the first time and we want a blank form, and second, when we go back to the *view* with all form data we just typed. So we need to add a condition (we will use `if` for that):
 


### PR DESCRIPTION
I removed the sentence "You should not rename POST to anything else (the only other valid value for method is GET, but we have no time to explain what the difference is)" and I added a brief explanation that GET is for getting pages and POST is for sending forms. I also added explicit mention of the `request.method` field to the paragraph so that the readers will recognise it later in code.

I know that the world is more complicated than "GET is for getting pages and POST is for sending forms" (one can send forms with GET) but I think giving that general idea helps with reading the code that follows (when we compare the `request.method` with `"POST"`) and this is not a complete lie.