### PR TITLE
Remove instructions to check if windows is 32-bit or 64-bit.

### DIFF
--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -8,13 +8,8 @@ Please install normal Python as follows, even when you have Anaconda installed o
 
 <!--sec data-title="Install Python: Windows" data-id="python_windows" data-collapse=true ces-->
 
-First check whether your computer is running a 32-bit version or a 64-bit version of Windows, on the "System type" line of the System Info page. To reach this page, try one of these methods:
-* Press the Windows key and Pause/Break key at the same time
-* Open your Control Panel from the Windows menu, then navigate to System & Security, then System
-* Press the Windows button, then navigate to Settings > System > About
-* Search the Windows Start menu for "System Information". To do that, click the Start button or press the Windows key, then begin to type `System Information`. It will start making suggestions as soon as you type. You can select the entry once it shows up.
 
-You can download Python for Windows from the website https://www.python.org/downloads/windows/. Click on the "Latest Python 3 Release - Python x.x.x" link. If your computer is running a **64-bit** version of Windows, download the **Windows x86-64 executable installer**. Otherwise, download the **Windows x86 executable installer**. After downloading the installer, you should run it (double-click on it) and follow the instructions there.
+You can download Python for Windows from the website https://www.python.org/downloads/windows/. Scroll down to the "Stable Release" section and find "Windows installer (64-bit)". After downloading the installer, you should run it (double-click on it) and follow the instructions there.
 
 One thing to watch out for: During the installation, you will notice a window marked "Setup". Make sure you tick the "Add Python {{ book.py_version }} to PATH" or 'Add Python to your environment variables" checkbox and click on "Install Now", as shown here (it may look a bit different if you are installing a different version):
 
@@ -22,7 +17,7 @@ One thing to watch out for: During the installation, you will notice a window ma
 
 When the installation completes, you may see a dialog box with a link you can follow to learn more about Python or about the version you installed. Close or cancel that dialog -- you'll be learning more in this tutorial!
 
-Note: If you are using an older version of Windows (7, Vista, or any older version) and the Python {{ book.py_version }} installer fails with an error, then install all Windows Updates and try to install Python again. If you still have the error, try installing Python version {{ book.py_min_release }} from [Python.org](https://www.python.org/downloads/windows/).
+Note: If you are using an older version of Windows (7, Vista, or any older version) and the Python {{ book.py_version }} installer fails with an error, then install all Windows Updates and try to install Python again. If you still have the error, try installing the 32-bit version of Python, or try installing an older version, Python {{ book.py_min_release }}, from [Python.org](https://www.python.org/downloads/windows/).
 
 > Django {{ book.django_version }} needs Python {{ book.py_min_version }} or greater, which does not support Windows XP or earlier versions.
 

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -17,7 +17,7 @@ One thing to watch out for: During the installation, you will notice a window ma
 
 When the installation completes, you may see a dialog box with a link you can follow to learn more about Python or about the version you installed. Close or cancel that dialog -- you'll be learning more in this tutorial!
 
-Note: If you are using an older version of Windows (10, 7, Vista, or any older version) and the Python {{ book.py_version }} installer fails with an error, then install all Windows Updates and try to install Python again. If you still have the error, try installing the 32-bit version of Python, or try installing an older version, Python {{ book.py_min_release }}, from [Python.org](https://www.python.org/downloads/windows/).
+Note: If you are using an Windows 10 and the Python {{ book.py_version }} installer fails with an error, then install all Windows Updates and try to install Python again. If you still have the error, try installing the 32-bit version of Python, or try installing an older version, Python {{ book.py_min_release }}, from [Python.org](https://www.python.org/downloads/windows/).
 
 > Django {{ book.django_version }} needs Python {{ book.py_min_version }} or greater, which does not support Windows XP or earlier versions.
 

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -17,7 +17,7 @@ One thing to watch out for: During the installation, you will notice a window ma
 
 When the installation completes, you may see a dialog box with a link you can follow to learn more about Python or about the version you installed. Close or cancel that dialog -- you'll be learning more in this tutorial!
 
-Note: If you are using an older version of Windows (7, Vista, or any older version) and the Python {{ book.py_version }} installer fails with an error, then install all Windows Updates and try to install Python again. If you still have the error, try installing the 32-bit version of Python, or try installing an older version, Python {{ book.py_min_release }}, from [Python.org](https://www.python.org/downloads/windows/).
+Note: If you are using an older version of Windows (10, 7, Vista, or any older version) and the Python {{ book.py_version }} installer fails with an error, then install all Windows Updates and try to install Python again. If you still have the error, try installing the 32-bit version of Python, or try installing an older version, Python {{ book.py_min_release }}, from [Python.org](https://www.python.org/downloads/windows/).
 
 > Django {{ book.django_version }} needs Python {{ book.py_min_version }} or greater, which does not support Windows XP or earlier versions.
 

--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -19,7 +19,7 @@ When the installation completes, you may see a dialog box with a link you can fo
 
 Note: If you are using an Windows 10 and the Python {{ book.py_version }} installer fails with an error, then install all Windows Updates and try to install Python again. If you still have the error, try installing the 32-bit version of Python, or try installing an older version, Python {{ book.py_min_release }}, from [Python.org](https://www.python.org/downloads/windows/).
 
-> Django {{ book.django_version }} needs Python {{ book.py_min_version }} or greater, which does not support Windows XP or earlier versions.
+> Django {{ book.django_version }} needs Python {{ book.py_min_version }} or greater, which does not support Windows 7 or earlier versions.
 
 <!--endsec-->
 


### PR DESCRIPTION
Windows 10 was the last version of windows to support 32-bit, that dates back to 10 years ago now, and the latest version, Windows 11, only has 64-bit, since 2021.  most manufacturers stopped had stopped building 32-bit computers by 2017 (https://www.quora.com/Are-32-bit-computers-still-being-produced-as-of-2017)

This change proposes we remove the big, fiddly chunk of instructions for "how to check whether you have 32-bit windows",

but!  it replaces them with a mention of using 32-bit in the already-existing "what to do if you have any problems" paragraph, later on.

my hope is that this makes life easier for the 90% of users on 64-bit windows, whilst not making things that much worse for people with older PCs.

am aware that other cultural contexts may be v different in respect, where there is a lot of older hardware around!

Changes in this pull request:

-
-
-
