### PR TITLE
Include/duplicate commandline prompt explanation in installation section

### DIFF
--- a/en/installation/README.md
+++ b/en/installation/README.md
@@ -33,7 +33,16 @@ To install software on your machine, follow the instructions below:
 
 ## Brief intro to the command line {#intro-command-line}
 Many of the steps below reference the "console", "terminal", "command window", or "command line" -- these all mean the same thing: a window on your computer where you can enter commands. When you get to the main tutorial, you'll learn more about the command line. For now, the main thing you need to know is how to open a command window and what it looks like:
+
 {% include "/intro_to_command_line/open_instructions.md" %}
+
+### The Command-line Prompt
+
+Now you know how to open a command line,
+we just need to understand what the "prompt" is.
+
+{% include "/intro_to_command_line/prompt.md" %}
+
 
 ## Install Python {#python}
 {% include "/python_installation/instructions.md" %}

--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -20,42 +20,13 @@ To start some experiments we need to open our command-line interface first.
 
 {% include "/intro_to_command_line/open_instructions.md" %}
 
-## Prompt
-
 You now should see a white or black window that is waiting for your commands.
 
-<!--sec data-title="Prompt: macOS and Linux" data-id="OSX_Linux_prompt" data-collapse=true ces-->
+### The command-line Prompt
+
+{% include "/intro_to_command_line/prompt.md" %}
 
 
-If you're on Mac or Linux, you probably see a `$`, like this:
-
-{% filename %}command-line{% endfilename %}
-```
-$
-```
-<!--endsec-->
-
-<!--sec data-title="Prompt: Windows" data-id="windows_prompt2" data-collapse=true ces-->
-
-
-On Windows, you probably see a `>`, like this:
-
-{% filename %}command-line{% endfilename %}
-```
->
-```
-
-Take a look at the Linux section just above now -- you'll see something more like that when you get to PythonAnywhere later in the tutorial.
-
-<!--endsec-->
-
-Each command will be prepended by a `$` or `>` and one space, but you should not type it. Your computer will do it for you. :)
-
-> Just a small note: in your case there may be something like `C:\Users\ola>` or `Olas-MacBook-Air:~ ola$` before the prompt sign, and this is 100% OK.
-
-The part up to and including the `$` or the `>` is called the *command line prompt*, or *prompt* for short. It prompts you to input something there.
-
-In the tutorial, when we want you to type in a command, we will include the `$` or `>`, and occasionally more to the left. Ignore the left part and only type in the command, which starts after the prompt.
 
 ## Your first command (YAY!)
 

--- a/en/intro_to_command_line/prompt.md
+++ b/en/intro_to_command_line/prompt.md
@@ -1,0 +1,32 @@
+<!--sec data-title="Prompt: macOS and Linux" data-id="OSX_Linux_prompt" data-collapse=true ces-->
+
+
+If you're on Mac or Linux, you probably see a `$`, like this:
+
+{% filename %}command-line{% endfilename %}
+```
+$
+```
+<!--endsec-->
+
+<!--sec data-title="Prompt: Windows" data-id="windows_prompt2" data-collapse=true ces-->
+
+
+On Windows, you probably see a `>`, like this:
+
+{% filename %}command-line{% endfilename %}
+```
+>
+```
+
+Take a look at the Linux section just above now -- you'll see something more like that when you get to PythonAnywhere later in the tutorial.
+
+<!--endsec-->
+
+Each command will be prepended by a `$` or `>` and one space, but you should not type it. Your computer will do it for you. :)
+
+> Just a small note: in your case there may be something like `C:\Users\ola>` or `Olas-MacBook-Air:~ ola$` before the prompt sign, and this is 100% OK.
+
+The part up to and including the `$` or the `>` is called the *command line prompt*, or *prompt* for short. It prompts you to input something there.
+
+In the tutorial, when we want you to type in a command, we will include the `$` or `>`, and occasionally more to the left. Ignore the left part and only type in the command, which starts after the prompt.


### PR DESCRIPTION
In the current workflow of our tutorial, attendees go through the installation instructions first, before going through the full intro to the command line.

But!  The installation instructions require them to _use_ the command line already.

This is why we already duplicate up the "how to open the command line" section, using an include.

But, attendees are still sometimes confused by the command line. Specifically, I've seen them copy-pasting the "$" from the listings into the terminal, and being confused by `$: command not found` errors.

This PR proposes that we add a second include to the installation instructions, to duplicate up the explanation of what the prompt is, from the commandline page.

Alternatives considered:

1. Remove all the dollars from commandline listings in the installation chapter. This would prevent the current failure mode, but it makes this section inconsistent with the rest of the tutorial

2. Add a very brief explanation saying "don't copy-paste the dollars, we'll explain why later". This could work, but concerned it would leave attendees with a low-level worry about some magical thing that they won't learn about for ages.

3. Reorganise the whole tutorial and put the intro to the command line before the installation instructions. This felt like a much more radical change.

