### PR TITLE
Tell people to create a GitHub Personal Access Token up-front

### DIFF
--- a/en/deploy/README.md
+++ b/en/deploy/README.md
@@ -132,9 +132,23 @@ $ git commit -m "My Django Girls app, first commit"
 
 ## Pushing your code to GitHub
 
-Go to [GitHub.com](https://www.github.com) and sign up for a new, free user account. (If you already did that in the workshop prep, that is great!) Be sure to remember your password (add it to your password manager, if you use one).
+Go to [GitHub.com](https://www.github.com) and sign up for a new, free user account.
+(If you already did that in the workshop prep, that is great!)
+Be sure to remember your password (add it to your password manager, if you use one).
 
-Then, create a new repository, giving it the name "my-first-blog". Leave the "initialize with a README" checkbox unchecked, leave the .gitignore option blank (we've done that manually) and leave the License as None.
+### Creating a Personal Access Token
+
+Now follow the instructions from GitHub to [create a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
+The token should have the 'repo' scope.
+Copy the value of the token, and save it somewhere safe (like a password manager).
+
+### Creating a new repository
+
+Back on the GitHub homepage,
+create a new repository, giving it the name "my-first-blog".
+Leave the "initialize with a README" checkbox unchecked,
+leave the .gitignore option blank (we've done that manually)
+and leave the License as None.
 
 ![](images/new_github_repo.png)
 
@@ -146,7 +160,9 @@ On the next screen, you'll be shown your repo's clone URL, which you will use in
 
 Now we need to hook up the Git repository on your computer to the one up on GitHub.
 
-Type the following into your console (replace `<your-github-username>` with the username you entered when you created your GitHub account, but without the angle-brackets -- the URL should match the clone URL you just saw).
+Type the following into your console
+(replace `<your-github-username>` with the username you entered when you created your GitHub account,
+but without the angle-brackets -- the URL should match the clone URL you just saw).
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -154,44 +170,12 @@ $ git remote add origin https://github.com/<your-github-username>/my-first-blog.
 $ git push -u origin HEAD
 ```
 
-When you push to GitHub, you'll be asked for your GitHub username and password (either right there in the command-line window or in a pop-up window), and after entering credentials you should see something like this:
+When you push to GitHub, you'll be asked for your GitHub username and password
+(either right there in the command-line window or in a pop-up window).
+Use the Personal Access Token you created earlier,
+not your account password.
 
-{% filename %}command-line{% endfilename %}
-```
-Counting objects: 6, done.
-Writing objects: 100% (6/6), 200 bytes | 0 bytes/s, done.
-Total 3 (delta 0), reused 0 (delta 0)
-To https://github.com/ola/my-first-blog.git
- * [new branch]      main -> main
-Branch main set up to track remote branch main from origin.
-```
-
-**Note** You will likely encounter the following error when trying to push to GitHub:
-```
-remote: Support for password authentication was removed on August 13, 2021.
-remote: Please see https://docs.github.com/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication.
-fatal: Authentication failed for 'https://github.com/<your-github-username>/my-first-blog.git/'
-```
-In this case, follow the instructions from GitHub to [create a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic). The token should have the 'repo' scope. Copy the value of the token, then try the git push command again. When you are prompted to enter your username and password, enter the access token instead of your password:
-
-1. Go to profile settings or go here: https://github.com/settings/profile
-2. Scroll down and click "Developer settings" on left-hand menu or go here: https://github.com/settings/apps
-3. On left-hand menu, press "Personal access tokens" to expand the dropdown menu. Click "Tokens (classic)"
-4. In the top-right, click "Generate new token", and then click "Generate new token (classic)". You will need to authenticate your account at this point.
-5. Fill in the form:
-  - Note: Django girls blog
-  - Expiration: No expiration (or if you want more security, choose 90 days)
-  - Select scopes: Check every box 
-6. Press "Generate token"
-7. Copy the token generated (it's the text string that likely starts with `ghp...`) and store this token somewhere secure as once you close this page, you will lose access to viewing this token and will need to generate a new one if you lose it. For example, you could store it in a password manager or even in a note on your computer.
-8. Run the command in the terminal again:
-  {% filename %}command-line{% endfilename %}
-  ```
-  $ git push -u origin HEAD
-  ```
-9. When the terminal asks for `username`, enter in your github username. Press enter.
-10. Next, it will ask for `password`. Do not use your github password as this method of authenticating ("logging in") is deprecated. Copy the token you just generated (either from github or wherever you carefully stored this token) and carefully paste it into the terminal. Note that as you paste or even type into the terminal for the password, nothing will appear (you can't see what you typed) for security reasons (it's designed like this on purpose). Press enter.
-11. If that worked, you will see the output as below. If you are unsuccesful, try to run `git push -u origin HEAD` again and make sure that you enter in your github username and the token (as the password) correctly.
+After entering credentials you should see something like this:
 
 {% filename %}command-line{% endfilename %}
 ```
@@ -205,9 +189,13 @@ Branch main set up to track remote branch main from origin.
 
 <!--TODO: maybe do ssh keys installs in install party, and point ppl who dont have it to an extension -->
 
-Your code is now on GitHub. Go and check it out!  You'll find it's in fine company – [Django](https://github.com/django/django), the [Django Girls Tutorial](https://github.com/DjangoGirls/tutorial), and many other great open source software projects also host their code on GitHub. :)
+Your code is now on GitHub. Go and check it out!
+You'll find it's in fine company – [Django](https://github.com/django/django),
+the [Django Girls Tutorial](https://github.com/DjangoGirls/tutorial),
+and many other great open source software projects also host their code on GitHub. :)
 
 {% include "/deploy/pythonanywhere.md" %}
+
 
 # Check out your site!
 


### PR DESCRIPTION
When we get to the `git push` stage, the tutorial currently tells people to attempt to use their normal github username and password.

It goes on to say "oh you will probably get an error", and tells people to create a PAT instead.

GitHub actually removed username & password auth in 2021.

So let's just tell people to use a PAT up-front.

ALSO: the tutorial used to tell people to follow the instructions on GitHub, but then also included its own instructions, inline. So I've removed them in favour of making github the single source of truth.

