### PR TITLE
Fixed #1890 -- Removed reference to non-existing <div> elements in German version

### DIFF
--- a/de/django_templates/README.md
+++ b/de/django_templates/README.md
@@ -20,7 +20,7 @@ Um eine Variable in einem Django-Template darzustellen, nutzen wir doppelte, ges
 {{ posts }}
 ```
 
-Versuche das in deinem `blog/templates/blog/post_list.html` Template. Öffne es in deinem Code-Editor und ersetze alles vom zweiten `<div>` bis zum dritten `</div>` mit `{{ posts }}`. Speichere die Datei und aktualisiere die Seite, um die Ergebnisse anzuzeigen.
+Versuche das in deinem `blog/templates/blog/post_list.html` Template. Öffne es in deinem Code-Editor und ersetze die `<article>`-Abschnitte mit `{{ posts }}`. Speichere die Datei und aktualisiere die Seite, um die Ergebnisse anzuzeigen.
 
 ![Abbildung 13.1](images/step1.png)
 


### PR DESCRIPTION
Changes in this pull request:

German version:
- Removed reference to to non-existing `<div>` elements in _Django templates_ chapter
- Added reference to `<article>` tags created in chapter _Introduction to HTML_

