### PR TITLE
translate section headings in HTML comments to DE

### DIFF
--- a/de/installation/README.md
+++ b/de/installation/README.md
@@ -18,8 +18,9 @@ Wenn du an einer [Django Girls Veranstaltung](https://djangogirls.org/events/) t
 
 In diesem Tutorial wirst du einen Blog bauen. Dafür wirst du während des Tutorials aufgefordert, verschiedene Software auf deinem Computer zu installieren und auch einige Online-Konten anzulegen, wenn sie gebraucht werden. Diese Seite fasst alle Installations- und Kontoeinrichtungs-Anweisungen an einer Stelle zusammen (das ist für einige Workshopformate sinnvoll).
 
-<!--sec data-title="Chromebook setup (if you're using one)"
-data-id="chromebook_setup" data-collapse=true ces--> {% include "/chromebook_setup/instructions.md" %}
+<!--sec data-title="Chromebook setup (falls du eines verwendest)"
+data-id="chromebook_setup" data-collapse=true ces-->
+{% include "/chromebook_setup/instructions.md" %}
 
 <!--endsec-->
 


### PR DESCRIPTION
Changes in this pull request:

- translated the section headers to German in (https://tutorial.djangogirls.org/de/installation/) . They were in HTML comments and possibly overlooked.
