### PR TITLE
Removed old manual import in the shell 

### DIFF
--- a/en/django_orm/README.md
+++ b/en/django_orm/README.md
@@ -37,23 +37,6 @@ Let's try to display all of our posts first. You can do that with the following 
 {% filename %}command-line{% endfilename %}
 ```python
 >>> Post.objects.all()
-Traceback (most recent call last):
-      File "<console>", line 1, in <module>
-NameError: name 'Post' is not defined
-```
-
-Oops! An error showed up. It tells us that there is no Post. It's correct – we forgot to import it first!
-
-{% filename %}command-line{% endfilename %}
-```python
->>> from blog.models import Post
-```
-
-We import the model `Post` from `blog.models`. Let's try displaying all posts again:
-
-{% filename %}command-line{% endfilename %}
-```python
->>> Post.objects.all()
 <QuerySet [<Post: my post title>, <Post: another post title>]>
 ```
 


### PR DESCRIPTION
Changes in this pull request:

I removed the following lines since in Django 5.2 has the [automatic import for shell ](https://docs.djangoproject.com/en/6.0/releases/5.2/#automatic-models-import-in-the-shell) so there is no need to import the model

`>>> from blog.models import Post`